### PR TITLE
Add procedural planet with LOD and orbit controls

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -123,216 +123,6 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1 &365404021
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 365404025}
-  - component: {fileID: 365404024}
-  - component: {fileID: 365404023}
-  - component: {fileID: 365404022}
-  m_Layer: 0
-  m_Name: Cube
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!65 &365404022
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 365404021}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!23 &365404023
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 365404021}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &365404024
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 365404021}
-  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &365404025
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 365404021}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1400000000
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1400000004}
-  - component: {fileID: 1400000003}
-  - component: {fileID: 1400000002}
-  - component: {fileID: 1400000001}
-  m_Layer: 0
-  m_Name: Additional Cube
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!65 &1400000001
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1400000000}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!23 &1400000002
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1400000000}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &1400000003
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1400000000}
-  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &1400000004
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1400000000}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 2, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &705507993
 GameObject:
   m_ObjectHideFlags: 0
@@ -427,6 +217,82 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &1849023456
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1849023457}
+  - component: {fileID: 1849023458}
+  m_Layer: 0
+  m_Name: Planet
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1849023457
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1849023456}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1849023458
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1849023456}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f8a814c12f14c5f9a3d4b403b31d85f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  planetRadius: 6371
+  seed: 1337
+  oceanDepth: 6
+  continentHeight: 2.4
+  mountainHeight: 7.5
+  oceanLevel: 0.47
+  detailStrength: 0.35
+  continentFrequency: 0.75
+  detailFrequency: 3.5
+  mountainFrequency: 7
+  continentOctaves: 4
+  detailOctaves: 5
+  mountainOctaves: 4
+  lacunarity: 2
+  persistence: 0.5
+  lodResolutions:
+    Array:
+    - 48
+    - 96
+    - 192
+  recalculateEveryEdit: 1
+  textureWidth: 2048
+  textureHeight: 1024
+  deepWaterColor: {r: 0.015, g: 0.05, b: 0.2, a: 1}
+  shallowWaterColor: {r: 0.078, g: 0.35, b: 0.6, a: 1}
+  beachColor: {r: 0.92, g: 0.85, b: 0.62, a: 1}
+  plainsColor: {r: 0.22, g: 0.6, b: 0.25, a: 1}
+  forestColor: {r: 0.12, g: 0.38, b: 0.18, a: 1}
+  mountainColor: {r: 0.45, g: 0.4, b: 0.37, a: 1}
+  snowColor: {r: 1, g: 1, b: 1, a: 1}
+  rotatePlanet: 1
+  rotationSpeed: 5
 --- !u!1 &963194225
 GameObject:
   m_ObjectHideFlags: 0
@@ -438,6 +304,7 @@ GameObject:
   - component: {fileID: 963194228}
   - component: {fileID: 963194227}
   - component: {fileID: 963194226}
+  - component: {fileID: 1983746598}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -485,7 +352,7 @@ Camera:
     width: 1
     height: 1
   near clip plane: 0.3
-  far clip plane: 1000
+  far clip plane: 500000
   field of view: 60
   orthographic: 0
   orthographic size: 5
@@ -504,6 +371,26 @@ Camera:
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
+--- !u!114 &1983746598
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963194225}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2d7c53e8bb2b49249a2846a5383271d7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  target: {fileID: 1849023457}
+  initialDistance: 16000
+  minDistance: 500
+  maxDistance: 35000
+  mouseOrbitSpeed: 120
+  keyboardOrbitSpeed: 60
+  zoomSpeed: 8000
+  smoothing: 12
 --- !u!4 &963194228
 Transform:
   m_ObjectHideFlags: 0
@@ -512,7 +399,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 963194225}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalPosition: {x: 0, y: 0, z: 16000}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Scripts.meta
+++ b/Assets/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0c765386b6ad4f44bbef6c0b3159b970
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OrbitCameraController.cs
+++ b/Assets/Scripts/OrbitCameraController.cs
@@ -1,0 +1,125 @@
+using UnityEngine;
+
+namespace WH40kCivFactoryBuilderGame
+{
+    [RequireComponent(typeof(Camera))]
+    public class OrbitCameraController : MonoBehaviour
+    {
+        [SerializeField]
+        private Transform target;
+
+        [SerializeField]
+        private float initialDistance = 16000f;
+
+        [SerializeField]
+        private float minDistance = 500f;
+
+        [SerializeField]
+        private float maxDistance = 35000f;
+
+        [SerializeField]
+        private float mouseOrbitSpeed = 120f;
+
+        [SerializeField]
+        private float keyboardOrbitSpeed = 60f;
+
+        [SerializeField]
+        private float zoomSpeed = 8000f;
+
+        [SerializeField]
+        private float smoothing = 12f;
+
+        private float yaw;
+        private float pitch;
+        private float distance;
+        private Vector3 currentVelocity;
+
+        private void Start()
+        {
+            if (target == null)
+            {
+                return;
+            }
+
+            Vector3 offset = transform.position - target.position;
+            distance = offset.magnitude;
+            if (distance <= Mathf.Epsilon)
+            {
+                distance = initialDistance;
+            }
+
+            Vector3 direction = offset.normalized;
+            pitch = Mathf.Asin(Mathf.Clamp(direction.y, -1f, 1f)) * Mathf.Rad2Deg;
+            yaw = Mathf.Atan2(direction.x, direction.z) * Mathf.Rad2Deg;
+            distance = Mathf.Clamp(distance, minDistance, maxDistance);
+
+            Cursor.lockState = CursorLockMode.None;
+            Cursor.visible = true;
+        }
+
+        private void LateUpdate()
+        {
+            if (target == null)
+            {
+                return;
+            }
+
+            HandleInput();
+            UpdateCameraPosition();
+        }
+
+        public void SetTarget(Transform newTarget)
+        {
+            target = newTarget;
+            Start();
+        }
+
+        private void HandleInput()
+        {
+            if (Input.GetMouseButton(0))
+            {
+                yaw += Input.GetAxis("Mouse X") * mouseOrbitSpeed * Time.deltaTime;
+                pitch -= Input.GetAxis("Mouse Y") * mouseOrbitSpeed * Time.deltaTime;
+            }
+
+            float horizontal = Input.GetAxis("Horizontal");
+            float vertical = Input.GetAxis("Vertical");
+            if (Mathf.Abs(horizontal) > 0.0001f)
+            {
+                yaw += horizontal * keyboardOrbitSpeed * Time.deltaTime;
+            }
+
+            if (Mathf.Abs(vertical) > 0.0001f)
+            {
+                pitch -= vertical * keyboardOrbitSpeed * Time.deltaTime;
+            }
+
+            float scroll = Input.GetAxis("Mouse ScrollWheel");
+            if (Mathf.Abs(scroll) > 0.0001f)
+            {
+                distance -= scroll * zoomSpeed;
+            }
+
+            if (Input.GetKey(KeyCode.PageUp) || Input.GetKey(KeyCode.E))
+            {
+                distance -= zoomSpeed * 0.5f * Time.deltaTime;
+            }
+
+            if (Input.GetKey(KeyCode.PageDown) || Input.GetKey(KeyCode.Q))
+            {
+                distance += zoomSpeed * 0.5f * Time.deltaTime;
+            }
+
+            pitch = Mathf.Clamp(pitch, -89f, 89f);
+            distance = Mathf.Clamp(distance, minDistance, maxDistance);
+        }
+
+        private void UpdateCameraPosition()
+        {
+            Quaternion rotation = Quaternion.Euler(pitch, yaw, 0f);
+            Vector3 desiredPosition = target.position - (rotation * Vector3.forward * distance);
+            transform.position = Vector3.SmoothDamp(transform.position, desiredPosition, ref currentVelocity, 1f / Mathf.Max(0.01f, smoothing));
+            transform.LookAt(target.position);
+        }
+    }
+}

--- a/Assets/Scripts/OrbitCameraController.cs.meta
+++ b/Assets/Scripts/OrbitCameraController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2d7c53e8bb2b49249a2846a5383271d7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/PlanetGenerator.cs
+++ b/Assets/Scripts/PlanetGenerator.cs
@@ -1,0 +1,533 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace WH40kCivFactoryBuilderGame
+{
+    [ExecuteAlways]
+    [DisallowMultipleComponent]
+    [RequireComponent(typeof(LODGroup))]
+    public class PlanetGenerator : MonoBehaviour
+    {
+        [Header("Scale")]
+        [SerializeField]
+        private float planetRadius = 6371f;
+
+        [SerializeField]
+        private int seed = 1337;
+
+        [Header("Elevation")]
+        [SerializeField]
+        private float oceanDepth = 6f;
+
+        [SerializeField]
+        private float continentHeight = 2.4f;
+
+        [SerializeField]
+        private float mountainHeight = 7.5f;
+
+        [SerializeField, Range(0.3f, 0.7f)]
+        private float oceanLevel = 0.47f;
+
+        [SerializeField, Range(0.05f, 1f)]
+        private float detailStrength = 0.35f;
+
+        [Header("Noise")]
+        [SerializeField]
+        private float continentFrequency = 0.75f;
+
+        [SerializeField]
+        private float detailFrequency = 3.5f;
+
+        [SerializeField]
+        private float mountainFrequency = 7f;
+
+        [SerializeField, Min(1)]
+        private int continentOctaves = 4;
+
+        [SerializeField, Min(1)]
+        private int detailOctaves = 5;
+
+        [SerializeField, Min(1)]
+        private int mountainOctaves = 4;
+
+        [SerializeField, Range(1.2f, 3f)]
+        private float lacunarity = 2f;
+
+        [SerializeField, Range(0.1f, 1f)]
+        private float persistence = 0.5f;
+
+        [Header("LOD")]
+        [SerializeField]
+        private int[] lodResolutions = new[] { 48, 96, 192 };
+
+        [SerializeField]
+        private bool recalculateEveryEdit = true;
+
+        [Header("Surface Texture")]
+        [SerializeField]
+        private int textureWidth = 2048;
+
+        [SerializeField]
+        private int textureHeight = 1024;
+
+        [SerializeField]
+        private Color deepWaterColor = new Color(0.015f, 0.05f, 0.2f);
+
+        [SerializeField]
+        private Color shallowWaterColor = new Color(0.078f, 0.35f, 0.6f);
+
+        [SerializeField]
+        private Color beachColor = new Color(0.92f, 0.85f, 0.62f);
+
+        [SerializeField]
+        private Color plainsColor = new Color(0.22f, 0.6f, 0.25f);
+
+        [SerializeField]
+        private Color forestColor = new Color(0.12f, 0.38f, 0.18f);
+
+        [SerializeField]
+        private Color mountainColor = new Color(0.45f, 0.4f, 0.37f);
+
+        [SerializeField]
+        private Color snowColor = Color.white;
+
+        [Header("Presentation")]
+        [SerializeField]
+        private bool rotatePlanet = true;
+
+        [SerializeField]
+        private float rotationSpeed = 5f;
+
+        private readonly Vector3[] faceDirections =
+        {
+            Vector3.up,
+            Vector3.down,
+            Vector3.left,
+            Vector3.right,
+            Vector3.forward,
+            Vector3.back
+        };
+
+        private readonly List<Mesh> generatedMeshes = new List<Mesh>();
+        private Material planetMaterial;
+        private Texture2D planetTexture;
+        private Vector3 noiseOffset;
+
+        private struct PlanetSample
+        {
+            public float height;
+            public bool isLand;
+            public float normalizedHeight;
+        }
+
+        private void OnEnable()
+        {
+            GeneratePlanet();
+        }
+
+        private void OnValidate()
+        {
+            if (!recalculateEveryEdit)
+            {
+                return;
+            }
+
+            GeneratePlanet();
+        }
+
+        private void Update()
+        {
+            if (!rotatePlanet || !Application.isPlaying)
+            {
+                return;
+            }
+
+            transform.Rotate(Vector3.up, rotationSpeed * Time.deltaTime, Space.Self);
+        }
+
+        public void GeneratePlanet()
+        {
+            if (!isActiveAndEnabled)
+            {
+                return;
+            }
+
+            if (!Application.isPlaying && !recalculateEveryEdit)
+            {
+                return;
+            }
+
+            if (lodResolutions == null || lodResolutions.Length == 0)
+            {
+                lodResolutions = new[] { 48, 96, 192 };
+            }
+
+            UpdateNoiseOffset();
+            ClearGeneratedChildren();
+            DisposeMeshes();
+            DisposeTexture();
+
+            var lodGroup = GetComponent<LODGroup>();
+            if (lodGroup == null)
+            {
+                lodGroup = gameObject.AddComponent<LODGroup>();
+            }
+
+            lodGroup.fadeMode = LODFadeMode.CrossFade;
+            lodGroup.animateCrossFading = true;
+
+            EnsureMaterial();
+            planetTexture = CreateSurfaceTexture(textureWidth, Mathf.Max(2, textureHeight));
+            planetMaterial.mainTexture = planetTexture;
+
+            var lods = new List<LOD>();
+            for (int i = 0; i < lodResolutions.Length; i++)
+            {
+                int resolution = Mathf.Max(8, lodResolutions[i]);
+                var mesh = BuildPlanetMesh(resolution);
+                generatedMeshes.Add(mesh);
+
+                var lodObject = new GameObject($"Planet_LOD_{resolution}");
+                lodObject.transform.SetParent(transform, false);
+                var meshFilter = lodObject.AddComponent<MeshFilter>();
+                var meshRenderer = lodObject.AddComponent<MeshRenderer>();
+                meshFilter.sharedMesh = mesh;
+                meshRenderer.sharedMaterial = planetMaterial;
+                meshRenderer.shadowCastingMode = ShadowCastingMode.On;
+                meshRenderer.receiveShadows = true;
+
+                float transitionHeight = lodResolutions.Length == 1
+                    ? 0.01f
+                    : Mathf.Lerp(0.6f, 0.05f, i / (float)(lodResolutions.Length - 1));
+
+                lods.Add(new LOD(transitionHeight, new[] { meshRenderer }));
+            }
+
+            lodGroup.SetLODs(lods.ToArray());
+            lodGroup.RecalculateBounds();
+        }
+
+        private void EnsureMaterial()
+        {
+            if (planetMaterial != null)
+            {
+                return;
+            }
+
+            var shader = Shader.Find("Standard");
+            planetMaterial = new Material(shader)
+            {
+                name = "Procedural Planet Material",
+                hideFlags = HideFlags.DontSave
+            };
+            planetMaterial.SetFloat("_Glossiness", 0.2f);
+            planetMaterial.SetFloat("_Metallic", 0.1f);
+        }
+
+        private void UpdateNoiseOffset()
+        {
+            const float goldenRatio = 1.61803398875f;
+            float offsetSeed = Mathf.Abs(seed) + 0.1234f;
+            noiseOffset = new Vector3(
+                offsetSeed * 1.193f,
+                offsetSeed * goldenRatio,
+                offsetSeed * 2.241f);
+        }
+
+        private void ClearGeneratedChildren()
+        {
+            for (int i = transform.childCount - 1; i >= 0; i--)
+            {
+                var child = transform.GetChild(i);
+                if (Application.isPlaying)
+                {
+                    Destroy(child.gameObject);
+                }
+                else
+                {
+                    DestroyImmediate(child.gameObject);
+                }
+            }
+        }
+
+        private void DisposeMeshes()
+        {
+            for (int i = 0; i < generatedMeshes.Count; i++)
+            {
+                var mesh = generatedMeshes[i];
+                if (mesh == null)
+                {
+                    continue;
+                }
+
+                if (Application.isPlaying)
+                {
+                    Destroy(mesh);
+                }
+                else
+                {
+                    DestroyImmediate(mesh);
+                }
+            }
+
+            generatedMeshes.Clear();
+        }
+
+        private void DisposeTexture()
+        {
+            if (planetTexture == null)
+            {
+                return;
+            }
+
+            if (Application.isPlaying)
+            {
+                Destroy(planetTexture);
+            }
+            else
+            {
+                DestroyImmediate(planetTexture);
+            }
+
+            planetTexture = null;
+        }
+
+        private Mesh BuildPlanetMesh(int resolution)
+        {
+            var mesh = new Mesh
+            {
+                name = $"PlanetMesh_{resolution}"
+            };
+
+            if (resolution * resolution * faceDirections.Length > 65535)
+            {
+                mesh.indexFormat = IndexFormat.UInt32;
+            }
+
+            var vertices = new List<Vector3>(resolution * resolution * faceDirections.Length);
+            var uvs = new List<Vector2>(vertices.Capacity);
+            var triangles = new List<int>((resolution - 1) * (resolution - 1) * 6 * faceDirections.Length);
+
+            foreach (var localUp in faceDirections)
+            {
+                GenerateTerrainFace(localUp, resolution, vertices, uvs, triangles);
+            }
+
+            mesh.SetVertices(vertices);
+            mesh.SetTriangles(triangles, 0);
+            mesh.SetUVs(0, uvs);
+            mesh.RecalculateNormals();
+            mesh.RecalculateBounds();
+
+            return mesh;
+        }
+
+        private void GenerateTerrainFace(Vector3 localUp, int resolution, List<Vector3> vertices, List<Vector2> uvs, List<int> triangles)
+        {
+            Vector3 axisA = new Vector3(localUp.y, localUp.z, localUp.x);
+            Vector3 axisB = Vector3.Cross(localUp, axisA);
+            int vertexStartIndex = vertices.Count;
+
+            for (int y = 0; y < resolution; y++)
+            {
+                for (int x = 0; x < resolution; x++)
+                {
+                    Vector2 percent = new Vector2(x / (float)(resolution - 1), y / (float)(resolution - 1));
+                    Vector3 pointOnCube = localUp
+                                          + (percent.x - 0.5f) * 2f * axisA
+                                          + (percent.y - 0.5f) * 2f * axisB;
+
+                    Vector3 pointOnSphere = pointOnCube.normalized;
+                    PlanetSample sample = SamplePoint(pointOnSphere);
+                    float surfaceRadius = planetRadius + sample.height;
+                    vertices.Add(pointOnSphere * surfaceRadius);
+
+                    float longitude = Mathf.Atan2(pointOnSphere.x, pointOnSphere.z);
+                    float latitude = Mathf.Asin(pointOnSphere.y);
+                    Vector2 uv = new Vector2(
+                        (longitude / (2f * Mathf.PI)) + 0.5f,
+                        (latitude / Mathf.PI) + 0.5f);
+
+                    uvs.Add(uv);
+                }
+            }
+
+            for (int y = 0; y < resolution - 1; y++)
+            {
+                for (int x = 0; x < resolution - 1; x++)
+                {
+                    int current = vertexStartIndex + x + y * resolution;
+                    int next = current + resolution;
+
+                    triangles.Add(current);
+                    triangles.Add(next);
+                    triangles.Add(current + 1);
+
+                    triangles.Add(current + 1);
+                    triangles.Add(next);
+                    triangles.Add(next + 1);
+                }
+            }
+        }
+
+        private PlanetSample SamplePoint(Vector3 pointOnUnitSphere)
+        {
+            float continentValue = FractalNoise(pointOnUnitSphere, continentFrequency, continentOctaves, persistence, lacunarity, false);
+            float landMask = Mathf.Clamp01((continentValue - oceanLevel) / Mathf.Max(0.0001f, 1f - oceanLevel));
+            float waterMask = Mathf.Clamp01((oceanLevel - continentValue) / Mathf.Max(0.0001f, oceanLevel));
+
+            float detailValue = FractalNoise(pointOnUnitSphere, detailFrequency, detailOctaves, persistence, lacunarity, false);
+            float mountainValue = FractalNoise(pointOnUnitSphere, mountainFrequency, mountainOctaves, persistence, lacunarity, true);
+
+            bool isLand = landMask > 0f;
+            float height;
+
+            if (isLand)
+            {
+                float baseLand = landMask * continentHeight;
+                float detailContribution = (detailValue - 0.5f) * 2f * detailStrength * continentHeight * landMask;
+                height = baseLand + detailContribution;
+                height = Mathf.Max(0f, height);
+                height += mountainValue * mountainHeight * landMask;
+            }
+            else
+            {
+                height = -waterMask * oceanDepth;
+            }
+
+            float normalizedHeight = Mathf.InverseLerp(-oceanDepth, continentHeight + mountainHeight, height);
+
+            return new PlanetSample
+            {
+                height = height,
+                isLand = isLand,
+                normalizedHeight = normalizedHeight
+            };
+        }
+
+        private float FractalNoise(Vector3 point, float baseFrequency, int octaves, float persistenceFactor, float lacunarityFactor, bool ridged)
+        {
+            float amplitude = 1f;
+            float totalAmplitude = 0f;
+            float frequency = Mathf.Max(0.0001f, baseFrequency);
+            float value = 0f;
+
+            for (int i = 0; i < octaves; i++)
+            {
+                Vector3 samplePoint = point * frequency + noiseOffset;
+                float noiseValue = Perlin3D(samplePoint);
+                if (ridged)
+                {
+                    noiseValue = 1f - Mathf.Abs(noiseValue * 2f - 1f);
+                    noiseValue *= noiseValue;
+                }
+
+                value += noiseValue * amplitude;
+                totalAmplitude += amplitude;
+
+                amplitude *= persistenceFactor;
+                frequency *= lacunarityFactor;
+            }
+
+            if (totalAmplitude > 0f)
+            {
+                value /= totalAmplitude;
+            }
+
+            return Mathf.Clamp01(value);
+        }
+
+        private float Perlin3D(Vector3 point)
+        {
+            float ab = Mathf.PerlinNoise(point.x, point.y);
+            float bc = Mathf.PerlinNoise(point.y, point.z);
+            float ca = Mathf.PerlinNoise(point.z, point.x);
+            return (ab + bc + ca) / 3f;
+        }
+
+        private Texture2D CreateSurfaceTexture(int width, int height)
+        {
+            if (width < 2)
+            {
+                width = 2;
+            }
+
+            if (height < 2)
+            {
+                height = 2;
+            }
+
+            var texture = new Texture2D(width, height, TextureFormat.RGBA32, true)
+            {
+                wrapMode = TextureWrapMode.Repeat,
+                filterMode = FilterMode.Trilinear,
+                name = "ProceduralPlanetTexture",
+                hideFlags = HideFlags.DontSave
+            };
+
+            var colors = new Color[width * height];
+
+            for (int y = 0; y < height; y++)
+            {
+                float v = y / (float)(height - 1);
+                float latitude = Mathf.Lerp(-Mathf.PI / 2f, Mathf.PI / 2f, v);
+                float sinLat = Mathf.Sin(latitude);
+                float cosLat = Mathf.Cos(latitude);
+
+                for (int x = 0; x < width; x++)
+                {
+                    float u = x / (float)(width - 1);
+                    float longitude = Mathf.Lerp(-Mathf.PI, Mathf.PI, u);
+                    float sinLon = Mathf.Sin(longitude);
+                    float cosLon = Mathf.Cos(longitude);
+
+                    Vector3 pointOnSphere = new Vector3(
+                        cosLat * sinLon,
+                        sinLat,
+                        cosLat * cosLon);
+
+                    PlanetSample sample = SamplePoint(pointOnSphere);
+                    colors[x + y * width] = EvaluateSurfaceColor(sample);
+                }
+            }
+
+            texture.SetPixels(colors);
+            texture.Apply(true, false);
+            return texture;
+        }
+
+        private Color EvaluateSurfaceColor(PlanetSample sample)
+        {
+            if (!sample.isLand)
+            {
+                float waterT = Mathf.InverseLerp(-oceanDepth, 0f, sample.height);
+                waterT = Mathf.SmoothStep(0f, 1f, waterT);
+                return Color.Lerp(deepWaterColor, shallowWaterColor, waterT);
+            }
+
+            float normalizedLand = Mathf.InverseLerp(0f, continentHeight + mountainHeight, sample.height);
+
+            if (normalizedLand < 0.2f)
+            {
+                float t = normalizedLand / 0.2f;
+                return Color.Lerp(beachColor, plainsColor, t);
+            }
+
+            if (normalizedLand < 0.45f)
+            {
+                float t = (normalizedLand - 0.2f) / 0.25f;
+                return Color.Lerp(plainsColor, forestColor, t);
+            }
+
+            if (normalizedLand < 0.75f)
+            {
+                float t = (normalizedLand - 0.45f) / 0.3f;
+                return Color.Lerp(forestColor, mountainColor, t);
+            }
+
+            float snowT = Mathf.Clamp01((normalizedLand - 0.75f) / 0.25f);
+            return Color.Lerp(mountainColor, snowColor, snowT);
+        }
+    }
+}

--- a/Assets/Scripts/PlanetGenerator.cs.meta
+++ b/Assets/Scripts/PlanetGenerator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6f8a814c12f14c5f9a3d4b403b31d85f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- implement a procedural planet generator that builds cube-sphere LOD meshes, applies noise-based elevation, and bakes a color texture for continents and oceans
- add an orbit camera controller that supports mouse and keyboard input for rotating and zooming around the planet
- refresh the sample scene to place the new planet, hook up the camera controller, and adjust camera distance and clipping for the earth-scale world

## Testing
- not run (Unity editor required)


------
https://chatgpt.com/codex/tasks/task_e_68d15904067c8322b9ab718f207c7d17