### PR TITLE
Fix planet visuals

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -267,23 +267,23 @@ MonoBehaviour:
   continentHeight: 2.4
   mountainHeight: 7.5
   oceanLevel: 0.47
-  detailStrength: 0.35
+  detailStrength: 0.45
   continentFrequency: 0.75
   detailFrequency: 3.5
   mountainFrequency: 7
   continentOctaves: 4
-  detailOctaves: 5
+  detailOctaves: 6
   mountainOctaves: 4
   lacunarity: 2
   persistence: 0.5
   lodResolutions:
     Array:
-    - 48
     - 96
     - 192
+    - 384
   recalculateEveryEdit: 1
-  textureWidth: 2048
-  textureHeight: 1024
+  textureWidth: 4096
+  textureHeight: 2048
   deepWaterColor: {r: 0.015, g: 0.05, b: 0.2, a: 1}
   shallowWaterColor: {r: 0.078, g: 0.35, b: 0.6, a: 1}
   beachColor: {r: 0.92, g: 0.85, b: 0.62, a: 1}
@@ -291,8 +291,6 @@ MonoBehaviour:
   forestColor: {r: 0.12, g: 0.38, b: 0.18, a: 1}
   mountainColor: {r: 0.45, g: 0.4, b: 0.37, a: 1}
   snowColor: {r: 1, g: 1, b: 1, a: 1}
-  rotatePlanet: 1
-  rotationSpeed: 5
 --- !u!1 &963194225
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/PlanetGenerator.cs
+++ b/Assets/Scripts/PlanetGenerator.cs
@@ -33,7 +33,7 @@ namespace WH40kCivFactoryBuilderGame
         private float oceanLevel = 0.47f;
 
         [SerializeField, Range(0.05f, 1f)]
-        private float detailStrength = 0.35f;
+        private float detailStrength = 0.45f;
 
         [Header("Noise")]
         [SerializeField]
@@ -49,7 +49,7 @@ namespace WH40kCivFactoryBuilderGame
         private int continentOctaves = 4;
 
         [SerializeField, Min(1)]
-        private int detailOctaves = 5;
+        private int detailOctaves = 6;
 
         [SerializeField, Min(1)]
         private int mountainOctaves = 4;
@@ -62,17 +62,17 @@ namespace WH40kCivFactoryBuilderGame
 
         [Header("LOD")]
         [SerializeField]
-        private int[] lodResolutions = new[] { 48, 96, 192 };
+        private int[] lodResolutions = new[] { 96, 192, 384 };
 
         [SerializeField]
         private bool recalculateEveryEdit = true;
 
         [Header("Surface Texture")]
         [SerializeField]
-        private int textureWidth = 2048;
+        private int textureWidth = 4096;
 
         [SerializeField]
-        private int textureHeight = 1024;
+        private int textureHeight = 2048;
 
         [SerializeField]
         private Color deepWaterColor = new Color(0.015f, 0.05f, 0.2f);
@@ -94,13 +94,6 @@ namespace WH40kCivFactoryBuilderGame
 
         [SerializeField]
         private Color snowColor = Color.white;
-
-        [Header("Presentation")]
-        [SerializeField]
-        private bool rotatePlanet = true;
-
-        [SerializeField]
-        private float rotationSpeed = 5f;
 
         private readonly Vector3[] faceDirections =
         {
@@ -137,36 +130,18 @@ namespace WH40kCivFactoryBuilderGame
             GeneratePlanet();
         }
 
+        private void OnValidate()
+        {
+            if (!recalculateEveryEdit)
+            {
+                return;
+            }
+
 #if UNITY_EDITOR
-        private void OnValidate()
-        {
-            if (!recalculateEveryEdit)
-            {
-                return;
-            }
-
             QueuePlanetGeneration();
-        }
 #else
-        private void OnValidate()
-        {
-            if (!recalculateEveryEdit)
-            {
-                return;
-            }
-
             GeneratePlanet();
-        }
 #endif
-
-        private void Update()
-        {
-            if (!rotatePlanet || !Application.isPlaying)
-            {
-                return;
-            }
-
-            transform.Rotate(Vector3.up, rotationSpeed * Time.deltaTime, Space.Self);
         }
 
         public void GeneratePlanet()
@@ -183,7 +158,7 @@ namespace WH40kCivFactoryBuilderGame
 
             if (lodResolutions == null || lodResolutions.Length == 0)
             {
-                lodResolutions = new[] { 48, 96, 192 };
+                lodResolutions = new[] { 96, 192, 384 };
             }
 
             UpdateNoiseOffset();
@@ -440,12 +415,12 @@ namespace WH40kCivFactoryBuilderGame
                     int next = current + resolution;
 
                     triangles.Add(current);
-                    triangles.Add(next);
                     triangles.Add(current + 1);
+                    triangles.Add(next);
 
                     triangles.Add(current + 1);
-                    triangles.Add(next);
                     triangles.Add(next + 1);
+                    triangles.Add(next);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- remove the runtime rotation behaviour from the procedural planet
- correct triangle winding so the generated mesh renders the exterior surface
- increase geometric, noise and texture detail for the default planet setup
- collapse the duplicated OnValidate definitions so the script no longer looks like it has merge conflicts

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68d1640f38748322b4d383f10d320e9d