### PR TITLE
Remove terrain texture binaries and proceduralize shader

### DIFF
--- a/Assets/Resources.meta
+++ b/Assets/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8f34879120eb4b279bbb2b8333244cd3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/WH30K.meta
+++ b/Assets/Resources/WH30K.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a137065281894270b280609996e175b6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/WH30K/PlanetTerrain.mat
+++ b/Assets/Resources/WH30K/PlanetTerrain.mat
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: PlanetTerrain
+  m_Shader: {fileID: 4800000, guid: a018cfe441804ffbb774bb799d920597, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs: []
+    m_Floats:
+    - _BlendSharpness: 4
+    - _NoiseIntensity: 0.35
+    - _TextureScale: 500
+    m_Colors:
+    - _DirtColor: {r: 0.36, g: 0.25, b: 0.15, a: 1}
+    - _RockColor: {r: 0.45, g: 0.43, b: 0.4, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Resources/WH30K/PlanetTerrain.mat.meta
+++ b/Assets/Resources/WH30K/PlanetTerrain.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2e5899bfb5b94d95aa7a182e426d7f64
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scenes/Prototype.meta
+++ b/Assets/Scenes/Prototype.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 10b16857d8e7400f83ea206fdd2a5662
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scenes/Prototype/WH30K_VS01.unity
+++ b/Assets/Scenes/Prototype/WH30K_VS01.unity
@@ -1,0 +1,438 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 120002}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 500
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 0
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &100000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 100001}
+  - component: {fileID: 100002}
+  - component: {fileID: 100003}
+  - component: {fileID: 100004}
+  - component: {fileID: 100005}
+  - component: {fileID: 100006}
+  - component: {fileID: 100007}
+  m_Layer: 0
+  m_Name: GameRoot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &100001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &100002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: adb3bb49a9a445a19492c33cd8777468, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  planetRadius: 3000
+  basePatchResolution: 48
+  maximumDepth: 5
+  splitDistance: 2400
+  splitFalloff: 1.8
+  lodUpdateInterval: 0.25
+  terrainMaterialResource: WH30K/PlanetTerrain
+  saveFileName: wh30k_vslice_save.json
+--- !u!114 &100003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c117ec2e50ff4a8db8d3bca3afdc594e, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+--- !u!114 &100004
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a55235ece2394358badf2a2e8baddd55, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+--- !u!114 &100005
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 456145cf744b449380d1d7ab52666796, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+--- !u!114 &100006
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 63e1953627164b42865b4b70cf5bfd69, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+--- !u!114 &100007
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 467311dff0604dfe861e13bcda9f11bb, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  tickInterval: 1
+  populationGrowthRate: 0.05
+  workforceRatio: 0.62
+  buildingSpacing: 220
+--- !u!1 &110000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 110001}
+  - component: {fileID: 110002}
+  - component: {fileID: 110003}
+  - component: {fileID: 110004}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &110001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 110000}
+  m_LocalRotation: {x: 0.087155744, y: 0.7071068, z: -0.087155744, w: 0.6963642}
+  m_LocalPosition: {x: 0, y: 3500, z: -6000}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 10, y: 90, z: 0}
+--- !u!20 &110002
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 110000}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 0
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 100000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!81 &110003
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 110000}
+  m_Enabled: 1
+--- !u!114 &110004
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 110000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 98f2e5957c3343698b649f4e141b6711, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  orbitSpeed: 180
+  zoomSpeed: 2
+  minDistance: 800
+  maxDistance: 9000
+  pitchLimits: {x: -80, y: 80}
+--- !u!1 &120000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 120001}
+  - component: {fileID: 120002}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &120001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 120000}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 1000, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!108 &120002
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 120000}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 1
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0

--- a/Assets/Scenes/Prototype/WH30K_VS01.unity.meta
+++ b/Assets/Scenes/Prototype/WH30K_VS01.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1ed1ec2fe8904b9ba135ce3faf9e64ba
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Camera.meta
+++ b/Assets/Scripts/Camera.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 009e094081e345d4b31dc7f28e109ec4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Camera/SimpleOrbitCamera.cs
+++ b/Assets/Scripts/Camera/SimpleOrbitCamera.cs
@@ -1,0 +1,93 @@
+using UnityEngine;
+
+namespace WH30K.CameraSystem
+{
+    /// <summary>
+    /// Minimal orbital camera that supports mouse orbiting/zooming and quick framing via Home/F keys.
+    /// </summary>
+    [RequireComponent(typeof(UnityEngine.Camera))]
+    public class SimpleOrbitCamera : MonoBehaviour
+    {
+        [SerializeField] private float orbitSpeed = 180f;
+        [SerializeField] private float zoomSpeed = 2f;
+        [SerializeField] private float minDistance = 800f;
+        [SerializeField] private float maxDistance = 9000f;
+        [SerializeField] private Vector2 pitchLimits = new Vector2(-80f, 80f);
+
+        private Transform target;
+        private float distance;
+        private float defaultDistance;
+        private float yaw;
+        private float pitch;
+        private bool hasTarget;
+
+        public void SetTarget(Transform newTarget, float approximateRadius)
+        {
+            target = newTarget;
+            defaultDistance = Mathf.Clamp(approximateRadius * 2.2f, minDistance, maxDistance);
+            distance = defaultDistance;
+            yaw = 135f;
+            pitch = 25f;
+            hasTarget = target != null;
+            if (hasTarget)
+            {
+                UpdateCameraTransform();
+            }
+        }
+
+        private void Update()
+        {
+            if (!hasTarget || target == null)
+            {
+                return;
+            }
+
+            if (Input.GetMouseButton(1))
+            {
+                yaw += Input.GetAxis("Mouse X") * orbitSpeed * Time.deltaTime;
+                pitch -= Input.GetAxis("Mouse Y") * orbitSpeed * 0.5f * Time.deltaTime;
+                pitch = Mathf.Clamp(pitch, pitchLimits.x, pitchLimits.y);
+            }
+
+            var scroll = Input.GetAxis("Mouse ScrollWheel");
+            if (Mathf.Abs(scroll) > 0.0001f)
+            {
+                distance *= 1f - scroll * zoomSpeed;
+                distance = Mathf.Clamp(distance, minDistance, maxDistance);
+            }
+
+            if (Input.GetKeyDown(KeyCode.Home) || Input.GetKeyDown(KeyCode.F))
+            {
+                FrameTarget();
+            }
+
+            UpdateCameraTransform();
+        }
+
+        private void UpdateCameraTransform()
+        {
+            if (target == null)
+            {
+                return;
+            }
+
+            var rotation = Quaternion.Euler(pitch, yaw, 0f);
+            var offset = rotation * (Vector3.back * distance);
+            transform.position = target.position + offset;
+            transform.LookAt(target.position, Vector3.up);
+        }
+
+        public void FrameTarget()
+        {
+            if (target == null)
+            {
+                return;
+            }
+
+            distance = defaultDistance;
+            yaw = 135f;
+            pitch = 25f;
+            UpdateCameraTransform();
+        }
+    }
+}

--- a/Assets/Scripts/Camera/SimpleOrbitCamera.cs.meta
+++ b/Assets/Scripts/Camera/SimpleOrbitCamera.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 98f2e5957c3343698b649f4e141b6711
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Game.meta
+++ b/Assets/Scripts/Game.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5ebe03060b54415abb06a89be4378796
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Game/GameSettings.cs
+++ b/Assets/Scripts/Game/GameSettings.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+
+namespace WH30K.Game
+{
+    /// <summary>
+    /// Centralised static repository for global configuration values such as selected difficulty
+    /// and seed. This keeps deterministic configuration accessible without relying on scene state.
+    /// </summary>
+    public static class GameSettings
+    {
+        public enum Difficulty
+        {
+            Easy,
+            Standard,
+            Hard,
+            Grim
+        }
+
+        [Serializable]
+        public struct DifficultyDefinition
+        {
+            public Difficulty difficulty;
+            public string displayName;
+            public float environmentHarshnessMultiplier;
+            public float resourceYieldMultiplier;
+            public float eventFrequencyMultiplier;
+        }
+
+        private static readonly Dictionary<Difficulty, DifficultyDefinition> Definitions =
+            new Dictionary<Difficulty, DifficultyDefinition>
+            {
+                {
+                    Difficulty.Easy,
+                    new DifficultyDefinition
+                    {
+                        difficulty = Difficulty.Easy,
+                        displayName = "Easy",
+                        environmentHarshnessMultiplier = 0.75f,
+                        resourceYieldMultiplier = 1.25f,
+                        eventFrequencyMultiplier = 0.75f
+                    }
+                },
+                {
+                    Difficulty.Standard,
+                    new DifficultyDefinition
+                    {
+                        difficulty = Difficulty.Standard,
+                        displayName = "Standard",
+                        environmentHarshnessMultiplier = 1f,
+                        resourceYieldMultiplier = 1f,
+                        eventFrequencyMultiplier = 1f
+                    }
+                },
+                {
+                    Difficulty.Hard,
+                    new DifficultyDefinition
+                    {
+                        difficulty = Difficulty.Hard,
+                        displayName = "Hard",
+                        environmentHarshnessMultiplier = 1.2f,
+                        resourceYieldMultiplier = 0.85f,
+                        eventFrequencyMultiplier = 1.1f
+                    }
+                },
+                {
+                    Difficulty.Grim,
+                    new DifficultyDefinition
+                    {
+                        difficulty = Difficulty.Grim,
+                        displayName = "Grim",
+                        environmentHarshnessMultiplier = 1.4f,
+                        resourceYieldMultiplier = 0.7f,
+                        eventFrequencyMultiplier = 1.35f
+                    }
+                }
+            };
+
+        private static readonly Difficulty[] DifficultyOrder =
+        {
+            Difficulty.Easy,
+            Difficulty.Standard,
+            Difficulty.Hard,
+            Difficulty.Grim
+        };
+
+        public static Difficulty CurrentDifficulty { get; private set; } = Difficulty.Standard;
+        public static int CurrentSeed { get; private set; }
+        public static bool HasActiveGame { get; private set; }
+
+        public static DifficultyDefinition GetDefinition(Difficulty difficulty) => Definitions[difficulty];
+
+        public static DifficultyDefinition GetCurrentDefinition() => Definitions[CurrentDifficulty];
+
+        public static IReadOnlyList<DifficultyDefinition> GetAllDefinitions()
+        {
+            var ordered = new List<DifficultyDefinition>(DifficultyOrder.Length);
+            foreach (var difficulty in DifficultyOrder)
+            {
+                ordered.Add(Definitions[difficulty]);
+            }
+
+            return ordered;
+        }
+
+        public static void StartNewGame(int seed, Difficulty difficulty)
+        {
+            CurrentSeed = seed;
+            CurrentDifficulty = difficulty;
+            HasActiveGame = true;
+        }
+
+        public static void ClearActiveGame()
+        {
+            HasActiveGame = false;
+        }
+
+        public static void ApplyLoadedState(int seed, Difficulty difficulty)
+        {
+            CurrentSeed = seed;
+            CurrentDifficulty = difficulty;
+            HasActiveGame = true;
+        }
+    }
+}

--- a/Assets/Scripts/Game/GameSettings.cs.meta
+++ b/Assets/Scripts/Game/GameSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ca0c773337364defbebb88f7ba88d5cb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Game/NewGameMenu.cs
+++ b/Assets/Scripts/Game/NewGameMenu.cs
@@ -1,0 +1,463 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+using WH30K.Game;
+using WH30K.Gameplay;
+using WH30K.Sim.Environment;
+using WH30K.Sim.Events;
+using WH30K.Sim.Resources;
+using WH30K.Sim.Settlements;
+
+namespace WH30K.UI
+{
+    /// <summary>
+    /// Runtime generated UI that exposes a lightweight "New Game" menu along with HUD readouts.
+    /// Programmatic creation keeps the scene authoring burden low while still enabling designer tweaking
+    /// by editing this single script.
+    /// </summary>
+    [RequireComponent(typeof(PlanetBootstrap))]
+    public class NewGameMenu : MonoBehaviour
+    {
+        private const float PanelWidth = 320f;
+        private const float PanelHeight = 210f;
+        private const float HudPanelWidth = 260f;
+
+        private PlanetBootstrap bootstrap;
+        private ResourceSystem resourceSystem;
+        private EnvironmentState environmentState;
+        private ColonyEventSystem colonyEventSystem;
+        private Settlement settlement;
+
+        private Canvas canvas;
+        private GameObject newGamePanel;
+        private InputField seedInput;
+        private Button startButton;
+        private Button saveButton;
+        private Button loadButton;
+        private Button difficultyButton;
+        private Text difficultyLabel;
+        private GameObject hudPanel;
+        private Text resourceText;
+        private Text environmentText;
+        private Text eventLogText;
+        private GameObject eventPanel;
+        private Text eventTitleText;
+        private Text eventBodyText;
+        private Text eventChoiceALabel;
+        private Text eventChoiceBLabel;
+        private Button eventChoiceAButton;
+        private Button eventChoiceBButton;
+
+        private readonly List<string> eventLogEntries = new List<string>();
+        private GameSettings.Difficulty selectedDifficulty = GameSettings.Difficulty.Standard;
+
+        private Action eventChoiceAHandler;
+        private Action eventChoiceBHandler;
+
+        private Font defaultFont;
+
+        private void Awake()
+        {
+            bootstrap = GetComponent<PlanetBootstrap>();
+            resourceSystem = GetComponent<ResourceSystem>();
+            environmentState = GetComponent<EnvironmentState>();
+            colonyEventSystem = GetComponent<ColonyEventSystem>();
+            settlement = GetComponent<Settlement>();
+
+            EnsureEventSystemExists();
+            BuildUI();
+            ConfigureDefaultValues();
+            ConfigureSystems();
+        }
+
+        public void ConfigureSystems()
+        {
+            bootstrap.ConfigureMenu(this);
+            resourceSystem.ConfigureMenu(this);
+            environmentState.ConfigureMenu(this);
+            colonyEventSystem.ConfigureMenu(this);
+            settlement.ConfigureMenu(this);
+        }
+
+        private void EnsureEventSystemExists()
+        {
+            if (FindObjectOfType<EventSystem>() != null)
+            {
+                return;
+            }
+
+            var eventSystemGO = new GameObject("EventSystem", typeof(EventSystem), typeof(StandaloneInputModule));
+            eventSystemGO.name = "UnityEventSystem";
+        }
+
+        private void BuildUI()
+        {
+            defaultFont = Resources.GetBuiltinResource<Font>("Arial.ttf");
+
+            var canvasGO = new GameObject("UI");
+            canvasGO.transform.SetParent(transform, false);
+            canvas = canvasGO.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            canvas.pixelPerfect = false;
+            canvasGO.AddComponent<CanvasScaler>().uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
+            canvasGO.AddComponent<GraphicRaycaster>();
+
+            BuildNewGamePanel(canvas.transform);
+            BuildHudPanel(canvas.transform);
+            BuildEventPanel(canvas.transform);
+        }
+
+        private void ConfigureDefaultValues()
+        {
+            var randomSeed = UnityEngine.Random.Range(0, int.MaxValue);
+            seedInput.text = randomSeed.ToString();
+            selectedDifficulty = GameSettings.Difficulty.Standard;
+            UpdateDifficultyButtonLabel();
+            ShowNewGamePanel(true);
+            ShowHud(false);
+            ShowEventPanel(false);
+        }
+
+        private void BuildNewGamePanel(Transform parent)
+        {
+            newGamePanel = CreatePanel("NewGamePanel", parent, new Vector2(PanelWidth, PanelHeight),
+                new Vector2(10f, -10f), TextAnchor.UpperLeft);
+
+            CreateLabel("Title", newGamePanel.transform, "New Game", 20, TextAnchor.UpperLeft,
+                new Vector2(0f, -10f), PanelWidth - 30f);
+
+            CreateLabel("SeedLabel", newGamePanel.transform, "Seed", 14, TextAnchor.UpperLeft,
+                new Vector2(0f, -50f), PanelWidth - 30f);
+            seedInput = CreateInputField("SeedInput", newGamePanel.transform, new Vector2(0f, -80f));
+
+            CreateLabel("DifficultyLabel", newGamePanel.transform, "Difficulty", 14, TextAnchor.UpperLeft,
+                new Vector2(0f, -120f), PanelWidth - 30f);
+            difficultyButton = CreateButton("DifficultyButton", newGamePanel.transform, new Vector2(0f, -150f),
+                "Standard", out difficultyLabel, PanelWidth - 40f);
+            difficultyButton.onClick.AddListener(CycleDifficulty);
+
+            startButton = CreateButton("StartButton", newGamePanel.transform, new Vector2(0f, -190f),
+                "Begin", out _, (PanelWidth - 50f) * 0.5f);
+            startButton.onClick.AddListener(OnStartClicked);
+
+            saveButton = CreateButton("SaveButton", newGamePanel.transform,
+                new Vector2((PanelWidth * 0.5f) + 5f, -190f), "Save", out _, (PanelWidth - 50f) * 0.5f);
+            saveButton.onClick.AddListener(OnSaveClicked);
+
+            loadButton = CreateButton("LoadButton", newGamePanel.transform,
+                new Vector2((PanelWidth * 0.5f) + 5f, -150f), "Load", out _, (PanelWidth - 50f) * 0.5f);
+            loadButton.onClick.AddListener(OnLoadClicked);
+        }
+
+        private void BuildHudPanel(Transform parent)
+        {
+            hudPanel = CreatePanel("HudPanel", parent, new Vector2(HudPanelWidth, 260f),
+                new Vector2(-10f, -10f), TextAnchor.UpperRight);
+
+            resourceText = CreateLabel("ResourceReadout", hudPanel.transform, string.Empty, 14, TextAnchor.UpperLeft,
+                new Vector2(-HudPanelWidth + 10f, -20f), HudPanelWidth - 20f);
+
+            environmentText = CreateLabel("EnvironmentReadout", hudPanel.transform, string.Empty, 14, TextAnchor.UpperLeft,
+                new Vector2(-HudPanelWidth + 10f, -120f), HudPanelWidth - 20f);
+
+            eventLogText = CreateLabel("EventLog", hudPanel.transform, "Log:\n", 12, TextAnchor.UpperLeft,
+                new Vector2(-HudPanelWidth + 10f, -200f), HudPanelWidth - 20f, 120f);
+        }
+
+        private void BuildEventPanel(Transform parent)
+        {
+            eventPanel = CreatePanel("EventPanel", parent, new Vector2(460f, 200f), new Vector2(0f, 0f), TextAnchor.MiddleCenter);
+
+            eventTitleText = CreateLabel("EventTitle", eventPanel.transform, string.Empty, 18, TextAnchor.UpperCenter,
+                new Vector2(0f, -15f), 420f);
+            eventBodyText = CreateLabel("EventBody", eventPanel.transform, string.Empty, 14, TextAnchor.UpperLeft,
+                new Vector2(-220f, -60f), 420f, 120f);
+
+            eventChoiceAButton = CreateButton("ChoiceA", eventPanel.transform, new Vector2(-140f, -150f),
+                "Choice A", out eventChoiceALabel, 180f);
+            eventChoiceBButton = CreateButton("ChoiceB", eventPanel.transform, new Vector2(140f, -150f),
+                "Choice B", out eventChoiceBLabel, 180f);
+
+            eventChoiceAButton.onClick.AddListener(() => eventChoiceAHandler?.Invoke());
+            eventChoiceBButton.onClick.AddListener(() => eventChoiceBHandler?.Invoke());
+        }
+
+        private GameObject CreatePanel(string name, Transform parent, Vector2 size, Vector2 anchoredPosition, TextAnchor anchor)
+        {
+            var panel = new GameObject(name, typeof(RectTransform), typeof(Image));
+            panel.transform.SetParent(parent, false);
+            var rect = panel.GetComponent<RectTransform>();
+            rect.sizeDelta = size;
+            switch (anchor)
+            {
+                case TextAnchor.UpperLeft:
+                    rect.anchorMin = new Vector2(0f, 1f);
+                    rect.anchorMax = new Vector2(0f, 1f);
+                    break;
+                case TextAnchor.UpperRight:
+                    rect.anchorMin = new Vector2(1f, 1f);
+                    rect.anchorMax = new Vector2(1f, 1f);
+                    break;
+                case TextAnchor.MiddleCenter:
+                    rect.anchorMin = new Vector2(0.5f, 0.5f);
+                    rect.anchorMax = new Vector2(0.5f, 0.5f);
+                    break;
+                default:
+                    rect.anchorMin = new Vector2(0.5f, 0.5f);
+                    rect.anchorMax = new Vector2(0.5f, 0.5f);
+                    break;
+            }
+
+            rect.anchoredPosition = anchoredPosition;
+            panel.GetComponent<Image>().color = new Color(0f, 0f, 0f, 0.5f);
+            return panel;
+        }
+
+        private Text CreateLabel(string name, Transform parent, string content, int fontSize, TextAnchor alignment,
+            Vector2 anchoredPosition, float width, float height = 60f)
+        {
+            var labelGO = new GameObject(name, typeof(RectTransform));
+            labelGO.transform.SetParent(parent, false);
+            var rect = labelGO.GetComponent<RectTransform>();
+            rect.sizeDelta = new Vector2(width, height);
+            rect.anchorMin = rect.anchorMax = new Vector2(0f, 1f);
+            rect.anchoredPosition = anchoredPosition;
+
+            var text = labelGO.AddComponent<Text>();
+            text.text = content;
+            text.fontSize = fontSize;
+            text.color = Color.white;
+            text.font = defaultFont;
+            text.alignment = alignment;
+            text.horizontalOverflow = HorizontalWrapMode.Wrap;
+            text.verticalOverflow = VerticalWrapMode.Truncate;
+            return text;
+        }
+
+        private InputField CreateInputField(string name, Transform parent, Vector2 anchoredPosition)
+        {
+            var inputGO = new GameObject(name, typeof(RectTransform), typeof(Image));
+            inputGO.transform.SetParent(parent, false);
+            var rect = inputGO.GetComponent<RectTransform>();
+            rect.sizeDelta = new Vector2(PanelWidth - 40f, 32f);
+            rect.anchorMin = rect.anchorMax = new Vector2(0f, 1f);
+            rect.anchoredPosition = anchoredPosition;
+
+            var image = inputGO.GetComponent<Image>();
+            image.color = new Color(0.15f, 0.15f, 0.15f, 0.9f);
+
+            var textGO = new GameObject("Text", typeof(RectTransform));
+            textGO.transform.SetParent(inputGO.transform, false);
+            var textRect = textGO.GetComponent<RectTransform>();
+            textRect.anchorMin = Vector2.zero;
+            textRect.anchorMax = Vector2.one;
+            textRect.offsetMin = new Vector2(10f, 6f);
+            textRect.offsetMax = new Vector2(-10f, -6f);
+
+            var text = textGO.AddComponent<Text>();
+            text.font = defaultFont;
+            text.fontSize = 14;
+            text.color = Color.white;
+            text.alignment = TextAnchor.MiddleLeft;
+
+            var placeholderGO = new GameObject("Placeholder", typeof(RectTransform));
+            placeholderGO.transform.SetParent(inputGO.transform, false);
+            var placeholderRect = placeholderGO.GetComponent<RectTransform>();
+            placeholderRect.anchorMin = Vector2.zero;
+            placeholderRect.anchorMax = Vector2.one;
+            placeholderRect.offsetMin = new Vector2(10f, 6f);
+            placeholderRect.offsetMax = new Vector2(-10f, -6f);
+
+            var placeholder = placeholderGO.AddComponent<Text>();
+            placeholder.font = defaultFont;
+            placeholder.fontSize = 14;
+            placeholder.color = new Color(1f, 1f, 1f, 0.35f);
+            placeholder.alignment = TextAnchor.MiddleLeft;
+            placeholder.text = "Random";
+
+            var inputField = inputGO.AddComponent<InputField>();
+            inputField.textComponent = text;
+            inputField.placeholder = placeholder;
+            inputField.contentType = InputField.ContentType.IntegerNumber;
+            return inputField;
+        }
+
+        private Button CreateButton(string name, Transform parent, Vector2 anchoredPosition, string label,
+            out Text labelText, float width)
+        {
+            var buttonGO = new GameObject(name, typeof(RectTransform), typeof(Image));
+            buttonGO.transform.SetParent(parent, false);
+            var rect = buttonGO.GetComponent<RectTransform>();
+            rect.sizeDelta = new Vector2(width, 36f);
+            rect.anchorMin = rect.anchorMax = new Vector2(0f, 1f);
+            rect.anchoredPosition = anchoredPosition;
+
+            var image = buttonGO.GetComponent<Image>();
+            image.color = new Color(0.2f, 0.2f, 0.2f, 0.9f);
+
+            var button = buttonGO.AddComponent<Button>();
+            var colors = button.colors;
+            colors.normalColor = image.color;
+            colors.highlightedColor = new Color(0.3f, 0.3f, 0.3f, 0.95f);
+            colors.pressedColor = new Color(0.1f, 0.1f, 0.1f, 1f);
+            button.colors = colors;
+
+            var textGO = new GameObject("Label", typeof(RectTransform));
+            textGO.transform.SetParent(buttonGO.transform, false);
+            var textRect = textGO.GetComponent<RectTransform>();
+            textRect.anchorMin = Vector2.zero;
+            textRect.anchorMax = Vector2.one;
+            textRect.offsetMin = Vector2.zero;
+            textRect.offsetMax = Vector2.zero;
+
+            labelText = textGO.AddComponent<Text>();
+            labelText.font = defaultFont;
+            labelText.fontSize = 16;
+            labelText.color = Color.white;
+            labelText.alignment = TextAnchor.MiddleCenter;
+            labelText.text = label;
+
+            return button;
+        }
+
+        private void CycleDifficulty()
+        {
+            var order = GameSettings.GetAllDefinitions();
+            var index = 0;
+            for (var i = 0; i < order.Count; i++)
+            {
+                if (order[i].difficulty == selectedDifficulty)
+                {
+                    index = i;
+                    break;
+                }
+            }
+
+            index = (index + 1) % order.Count;
+            selectedDifficulty = order[index].difficulty;
+            UpdateDifficultyButtonLabel();
+        }
+
+        private void UpdateDifficultyButtonLabel()
+        {
+            var definition = GameSettings.GetDefinition(selectedDifficulty);
+            difficultyLabel.text = definition.displayName;
+        }
+
+        private void OnStartClicked()
+        {
+            var seed = UnityEngine.Random.Range(0, int.MaxValue);
+            if (!string.IsNullOrWhiteSpace(seedInput.text) && int.TryParse(seedInput.text, out var parsedSeed))
+            {
+                seed = parsedSeed;
+            }
+
+            bootstrap.BeginNewGame(seed, selectedDifficulty);
+        }
+
+        private void OnSaveClicked()
+        {
+            bootstrap.SaveToFile();
+        }
+
+        private void OnLoadClicked()
+        {
+            bootstrap.LoadFromFile();
+        }
+
+        public void ShowNewGamePanel(bool visible)
+        {
+            newGamePanel.SetActive(visible);
+            saveButton.interactable = !visible;
+            loadButton.interactable = true;
+        }
+
+        public void ShowHud(bool visible)
+        {
+            hudPanel.SetActive(visible);
+        }
+
+        public void ShowEventPanel(bool visible)
+        {
+            eventPanel.SetActive(visible);
+        }
+
+        public void SetDifficulty(GameSettings.Difficulty difficulty)
+        {
+            selectedDifficulty = difficulty;
+            UpdateDifficultyButtonLabel();
+        }
+
+        public void SetSeed(int seed)
+        {
+            seedInput.text = seed.ToString();
+        }
+
+        public void UpdateResourceReadout(ResourceSnapshot snapshot)
+        {
+            var builder = new StringBuilder();
+            builder.AppendLine("Resources");
+            builder.AppendLine($"Population: {snapshot.Population:0}");
+            builder.AppendLine($"Workforce: {snapshot.Workforce:0}");
+            builder.AppendLine($"Production: {snapshot.ProductionPerCycle:0.0}");
+            builder.AppendLine($"Upkeep: {snapshot.UpkeepPerCycle:0.0}");
+            builder.AppendLine($"Net: {snapshot.NetProduction:0.0}");
+            builder.Append($"Stockpile: {snapshot.Stockpile:0.0}");
+            resourceText.text = builder.ToString();
+        }
+
+        public void UpdateEnvironmentReadout(EnvironmentSnapshot snapshot)
+        {
+            var builder = new StringBuilder();
+            builder.AppendLine("Environment");
+            builder.AppendLine($"CO₂ Level: {snapshot.Co2:0.0}");
+            builder.AppendLine($"O₂ Level: {snapshot.O2:0.0}");
+            builder.AppendLine($"Water Pollution: {snapshot.WaterPollution:0.0}");
+            builder.Append($"Δ Global Temp: {snapshot.GlobalTemperatureOffset:0.00}°C");
+            environmentText.text = builder.ToString();
+        }
+
+        public void AppendEventLog(string logEntry)
+        {
+            eventLogEntries.Add(logEntry);
+            while (eventLogEntries.Count > 6)
+            {
+                eventLogEntries.RemoveAt(0);
+            }
+
+            var builder = new StringBuilder();
+            builder.AppendLine("Log:");
+            foreach (var entry in eventLogEntries)
+            {
+                builder.AppendLine(entry);
+            }
+
+            eventLogText.text = builder.ToString();
+        }
+
+        public void PromptEvent(string title, string body, string optionAText, Action optionA, string optionBText, Action optionB)
+        {
+            eventTitleText.text = title;
+            eventBodyText.text = body;
+            eventChoiceALabel.text = optionAText;
+            eventChoiceBLabel.text = optionBText;
+
+            eventChoiceAHandler = () =>
+            {
+                ShowEventPanel(false);
+                optionA?.Invoke();
+            };
+
+            eventChoiceBHandler = () =>
+            {
+                ShowEventPanel(false);
+                optionB?.Invoke();
+            };
+
+            ShowEventPanel(true);
+        }
+    }
+}

--- a/Assets/Scripts/Game/NewGameMenu.cs.meta
+++ b/Assets/Scripts/Game/NewGameMenu.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c117ec2e50ff4a8db8d3bca3afdc594e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Planet.meta
+++ b/Assets/Scripts/Planet.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fdc064908076445a8e178afac4420611
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Planet/LODPatch.cs
+++ b/Assets/Scripts/Planet/LODPatch.cs
@@ -1,0 +1,229 @@
+using UnityEngine;
+
+namespace WH30K.Planet
+{
+    /// <summary>
+    /// Represents a single quad patch on one face of the cube-sphere. Handles mesh generation
+    /// and dynamic subdivision based on camera distance.
+    /// </summary>
+    [RequireComponent(typeof(MeshFilter), typeof(MeshRenderer))]
+    public class LODPatch : MonoBehaviour
+    {
+        private LODPlanet planet;
+        private Vector3 localUp;
+        private Vector3 axisA;
+        private Vector3 axisB;
+        private Vector2 uvMin;
+        private Vector2 uvMax;
+        private int depth;
+
+        private Mesh mesh;
+        private MeshFilter meshFilter;
+        private MeshRenderer meshRenderer;
+        private LODPatch[] children;
+        private Vector3 cachedCenter;
+        private bool centerDirty = true;
+
+        public void Initialize(LODPlanet parentPlanet, Vector3 faceNormal, Vector2 uvStart, Vector2 uvEnd, int lodDepth)
+        {
+            planet = parentPlanet;
+            localUp = faceNormal.normalized;
+            axisA = new Vector3(localUp.y, localUp.z, -localUp.x).normalized;
+            axisB = Vector3.Cross(localUp, axisA).normalized;
+            uvMin = uvStart;
+            uvMax = uvEnd;
+            depth = lodDepth;
+            transform.localPosition = Vector3.zero;
+            transform.localRotation = Quaternion.identity;
+
+            meshFilter = GetComponent<MeshFilter>();
+            meshRenderer = GetComponent<MeshRenderer>();
+            meshRenderer.sharedMaterial = planet.TerrainMaterial;
+
+            mesh = new Mesh { name = $"PatchMesh_{depth}" };
+            mesh.indexFormat = UnityEngine.Rendering.IndexFormat.UInt32;
+            meshFilter.sharedMesh = mesh;
+
+            Regenerate();
+        }
+
+        public void RefreshLOD(Vector3 cameraPosition)
+        {
+            if (planet == null)
+            {
+                return;
+            }
+
+            var center = GetCenterWorld();
+            var distance = Vector3.Distance(cameraPosition, center);
+            var splitThreshold = planet.SplitDistance / Mathf.Pow(planet.SplitFalloff, depth + 1);
+            var mergeThreshold = splitThreshold * 1.6f;
+
+            if (distance < splitThreshold && depth < planet.MaxDepth)
+            {
+                Subdivide();
+                if (children != null)
+                {
+                    foreach (var child in children)
+                    {
+                        child.RefreshLOD(cameraPosition);
+                    }
+
+                    SetVisible(false);
+                }
+            }
+            else
+            {
+                if (children != null)
+                {
+                    if (distance > mergeThreshold || depth == 0)
+                    {
+                        DestroyChildren();
+                        SetVisible(true);
+                    }
+                    else
+                    {
+                        foreach (var child in children)
+                        {
+                            child.RefreshLOD(cameraPosition);
+                        }
+
+                        SetVisible(false);
+                    }
+                }
+                else
+                {
+                    SetVisible(true);
+                }
+            }
+        }
+
+        private void Subdivide()
+        {
+            if (children != null)
+            {
+                return;
+            }
+
+            children = new LODPatch[4];
+            var midpoint = (uvMin + uvMax) * 0.5f;
+            var depthChild = depth + 1;
+
+            children[0] = CreateChild(new Vector2(uvMin.x, uvMin.y), new Vector2(midpoint.x, midpoint.y), depthChild, "SW");
+            children[1] = CreateChild(new Vector2(midpoint.x, uvMin.y), new Vector2(uvMax.x, midpoint.y), depthChild, "SE");
+            children[2] = CreateChild(new Vector2(uvMin.x, midpoint.y), new Vector2(midpoint.x, uvMax.y), depthChild, "NW");
+            children[3] = CreateChild(new Vector2(midpoint.x, midpoint.y), new Vector2(uvMax.x, uvMax.y), depthChild, "NE");
+        }
+
+        private LODPatch CreateChild(Vector2 childUvMin, Vector2 childUvMax, int childDepth, string suffix)
+        {
+            var go = new GameObject($"{name}_{suffix}");
+            go.transform.SetParent(transform.parent, false);
+            var patch = go.AddComponent<LODPatch>();
+            patch.Initialize(planet, localUp, childUvMin, childUvMax, childDepth);
+            return patch;
+        }
+
+        private void DestroyChildren()
+        {
+            if (children == null)
+            {
+                return;
+            }
+
+            for (var i = 0; i < children.Length; i++)
+            {
+                if (children[i] != null)
+                {
+                    Destroy(children[i].gameObject);
+                }
+            }
+
+            children = null;
+        }
+
+        private void SetVisible(bool visible)
+        {
+            if (meshRenderer != null)
+            {
+                meshRenderer.enabled = visible;
+            }
+
+            if (meshFilter != null && meshFilter.sharedMesh != mesh)
+            {
+                meshFilter.sharedMesh = mesh;
+            }
+        }
+
+        private void Regenerate()
+        {
+            centerDirty = true;
+            var resolution = planet.GetResolutionForDepth(depth);
+            var vertexCount = resolution * resolution;
+            var vertices = new Vector3[vertexCount];
+            var normals = new Vector3[vertexCount];
+            var uvs = new Vector2[vertexCount];
+            var triangles = new int[(resolution - 1) * (resolution - 1) * 6];
+
+            var triIndex = 0;
+            for (var y = 0; y < resolution; y++)
+            {
+                for (var x = 0; x < resolution; x++)
+                {
+                    var i = x + y * resolution;
+                    var percentX = Mathf.Lerp(uvMin.x, uvMax.x, x / (float)(resolution - 1));
+                    var percentY = Mathf.Lerp(uvMin.y, uvMax.y, y / (float)(resolution - 1));
+                    var pointOnCube = localUp + (percentX - 0.5f) * 2f * axisA + (percentY - 0.5f) * 2f * axisB;
+                    var pointOnSphere = pointOnCube.normalized;
+                    var vertex = planet.EvaluateSurfacePoint(pointOnSphere);
+                    vertices[i] = vertex;
+                    normals[i] = pointOnSphere;
+                    uvs[i] = new Vector2(percentX, percentY);
+
+                    if (x == resolution - 1 || y == resolution - 1)
+                    {
+                        continue;
+                    }
+
+                    triangles[triIndex++] = i;
+                    triangles[triIndex++] = i + resolution + 1;
+                    triangles[triIndex++] = i + resolution;
+
+                    triangles[triIndex++] = i;
+                    triangles[triIndex++] = i + 1;
+                    triangles[triIndex++] = i + resolution + 1;
+                }
+            }
+
+            mesh.Clear();
+            mesh.vertices = vertices;
+            mesh.normals = normals;
+            mesh.uv = uvs;
+            mesh.triangles = triangles;
+        }
+
+        private Vector3 GetCenterWorld()
+        {
+            if (!centerDirty)
+            {
+                return cachedCenter;
+            }
+
+            var midX = (uvMin.x + uvMax.x) * 0.5f;
+            var midY = (uvMin.y + uvMax.y) * 0.5f;
+            var pointOnCube = localUp + (midX - 0.5f) * 2f * axisA + (midY - 0.5f) * 2f * axisB;
+            var pointOnSphere = pointOnCube.normalized;
+            cachedCenter = planet.EvaluateSurfacePoint(pointOnSphere);
+            centerDirty = false;
+            return cachedCenter;
+        }
+
+        private void OnDestroy()
+        {
+            if (mesh != null)
+            {
+                Destroy(mesh);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Planet/LODPatch.cs.meta
+++ b/Assets/Scripts/Planet/LODPatch.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c48db8b53db44c878296dc0742d20fb0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Planet/LODPlanet.cs
+++ b/Assets/Scripts/Planet/LODPlanet.cs
@@ -1,0 +1,209 @@
+using System;
+using UnityEngine;
+
+namespace WH30K.Planet
+{
+    /// <summary>
+    /// Manages the life-cycle of a cube-sphere LOD planet. Responsible for spawning the patch hierarchy
+    /// and feeding shared parameters to each patch.
+    /// </summary>
+    public class LODPlanet : MonoBehaviour
+    {
+        [SerializeField] private float radius = 3000f;
+        [SerializeField] private int baseResolution = 48;
+        [SerializeField] private int maxDepth = 5;
+        [SerializeField] private float splitDistance = 2400f;
+        [SerializeField] private float splitFalloff = 1.8f;
+        [SerializeField] private float lodUpdateInterval = 0.25f;
+
+        public float Radius => radius;
+        public int BaseResolution => Mathf.Max(8, baseResolution);
+        public int MaxDepth => Mathf.Max(0, maxDepth);
+        public float SplitDistance => splitDistance;
+        public float SplitFalloff => Mathf.Max(1.01f, splitFalloff);
+        public float LodUpdateInterval => Mathf.Max(0.05f, lodUpdateInterval);
+        public int Seed { get; private set; }
+        public Material TerrainMaterial { get; private set; }
+        public float SeaLevel => radius - 120f;
+
+        private readonly Vector3[] faceDirections =
+        {
+            Vector3.up,
+            Vector3.down,
+            Vector3.left,
+            Vector3.right,
+            Vector3.forward,
+            Vector3.back
+        };
+
+        private LODPatch[] rootPatches;
+        private Camera referenceCamera;
+        private float elapsed;
+
+        private Vector3 continentOffset;
+        private Vector3 ridgeOffset;
+        private float continentScale;
+        private float ridgeScale;
+        private float ridgeWeight;
+
+        public void BuildPlanet(int seed, Material material)
+        {
+            Seed = seed;
+            TerrainMaterial = material;
+
+            continentOffset = GenerateOffset(seed, 17);
+            ridgeOffset = GenerateOffset(seed, 83);
+            continentScale = Mathf.Lerp(0.65f, 1.35f, PseudoRandom(seed * 1.11f));
+            ridgeScale = Mathf.Lerp(2.6f, 3.8f, PseudoRandom(seed * 2.77f));
+            ridgeWeight = Mathf.Lerp(0.35f, 0.65f, PseudoRandom(seed * 3.91f));
+
+            ClearExisting();
+            rootPatches = new LODPatch[faceDirections.Length];
+
+            for (var i = 0; i < faceDirections.Length; i++)
+            {
+                var patchGO = new GameObject($"Patch_{i}");
+                patchGO.transform.SetParent(transform, false);
+                var patch = patchGO.AddComponent<LODPatch>();
+                patch.Initialize(this, faceDirections[i], Vector2.zero, Vector2.one, 0);
+                rootPatches[i] = patch;
+            }
+        }
+
+        public void ApplyConfiguration(float targetRadius, int baseRes, int depthLimit, float distance, float falloff,
+            float updateInterval)
+        {
+            radius = Mathf.Max(100f, targetRadius);
+            baseResolution = Mathf.Max(8, baseRes);
+            maxDepth = Mathf.Max(0, depthLimit);
+            splitDistance = Mathf.Max(radius * 0.2f, distance);
+            splitFalloff = Mathf.Max(1.01f, falloff);
+            lodUpdateInterval = Mathf.Max(0.05f, updateInterval);
+        }
+
+        private void ClearExisting()
+        {
+            if (rootPatches == null)
+            {
+                return;
+            }
+
+            for (var i = 0; i < rootPatches.Length; i++)
+            {
+                if (rootPatches[i] != null)
+                {
+                    Destroy(rootPatches[i].gameObject);
+                }
+            }
+        }
+
+        private void Update()
+        {
+            if (rootPatches == null || rootPatches.Length == 0)
+            {
+                return;
+            }
+
+            if (referenceCamera == null)
+            {
+                referenceCamera = Camera.main;
+                if (referenceCamera == null)
+                {
+                    return;
+                }
+            }
+
+            elapsed += Time.deltaTime;
+            if (elapsed < LodUpdateInterval)
+            {
+                return;
+            }
+
+            elapsed = 0f;
+            var cameraPosition = referenceCamera.transform.position;
+            foreach (var patch in rootPatches)
+            {
+                patch?.RefreshLOD(cameraPosition);
+            }
+        }
+
+        internal int GetResolutionForDepth(int depth)
+        {
+            var resolution = BaseResolution;
+            for (var i = 0; i < depth; i++)
+            {
+                resolution = Mathf.Max(8, resolution / 2);
+            }
+
+            return resolution;
+        }
+
+        internal float EvaluateHeight(Vector3 pointOnUnitSphere)
+        {
+            var continents = Mathf.PerlinNoise(pointOnUnitSphere.x * continentScale + continentOffset.x,
+                pointOnUnitSphere.y * continentScale + continentOffset.y);
+            continents = Mathf.Pow(continents, 3f);
+
+            var ridged = Mathf.PerlinNoise(pointOnUnitSphere.z * ridgeScale + ridgeOffset.x,
+                pointOnUnitSphere.x * ridgeScale + ridgeOffset.y);
+            ridged = 1f - Mathf.Abs(ridged * 2f - 1f);
+            ridged = Mathf.Pow(ridged, 3.2f);
+
+            var elevation = continents * 520f + ridged * 380f * ridgeWeight - 210f;
+            return radius + elevation;
+        }
+
+        internal Vector3 EvaluateSurfacePoint(Vector3 direction)
+        {
+            var normalised = direction.normalized;
+            var height = EvaluateHeight(normalised);
+            return normalised * height;
+        }
+
+        internal bool TryFindLandPoint(int attempts, System.Random random, out Vector3 position, out Vector3 normal)
+        {
+            for (var i = 0; i < attempts; i++)
+            {
+                var direction = new Vector3((float)random.NextDouble() * 2f - 1f,
+                    (float)random.NextDouble() * 2f - 1f,
+                    (float)random.NextDouble() * 2f - 1f);
+                if (direction.sqrMagnitude < 0.001f)
+                {
+                    continue;
+                }
+
+                var point = EvaluateSurfacePoint(direction);
+                var height = point.magnitude;
+                if (height < SeaLevel)
+                {
+                    continue;
+                }
+
+                position = point;
+                normal = point.normalized;
+                return true;
+            }
+
+            position = Vector3.zero;
+            normal = Vector3.up;
+            return false;
+        }
+
+        private static Vector3 GenerateOffset(int seed, int salt)
+        {
+            var random = new System.Random(seed ^ salt);
+            return new Vector3((float)random.NextDouble() * 1000f, (float)random.NextDouble() * 1000f,
+                (float)random.NextDouble() * 1000f);
+        }
+
+        private static float PseudoRandom(double seed)
+        {
+            return (float)(new System.Random((int)(seed * 1000d) ^ 9176).NextDouble());
+        }
+
+        public void SetCamera(Camera camera)
+        {
+            referenceCamera = camera;
+        }
+    }
+}

--- a/Assets/Scripts/Planet/LODPlanet.cs.meta
+++ b/Assets/Scripts/Planet/LODPlanet.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 54103930ecc7417287497e6d509f20ea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Planet/PlanetBootstrap.cs
+++ b/Assets/Scripts/Planet/PlanetBootstrap.cs
@@ -1,0 +1,222 @@
+using System;
+using System.IO;
+using UnityEngine;
+using WH30K.CameraSystem;
+using WH30K.Game;
+using WH30K.Planet;
+using WH30K.Sim.Environment;
+using WH30K.Sim.Events;
+using WH30K.Sim.Resources;
+using WH30K.Sim.Settlements;
+using WH30K.UI;
+
+namespace WH30K.Gameplay
+{
+    /// <summary>
+    /// High-level orchestrator that wires the procedural planet, settlement simulation, UI and persistence together.
+    /// </summary>
+    [RequireComponent(typeof(NewGameMenu))]
+    [RequireComponent(typeof(ResourceSystem))]
+    [RequireComponent(typeof(EnvironmentState))]
+    [RequireComponent(typeof(ColonyEventSystem))]
+    [RequireComponent(typeof(Settlement))]
+    public class PlanetBootstrap : MonoBehaviour
+    {
+        [Header("Planet")]
+        [SerializeField] private float planetRadius = 3000f;
+        [SerializeField] private int basePatchResolution = 48;
+        [SerializeField] private int maximumDepth = 5;
+        [SerializeField] private float splitDistance = 2400f;
+        [SerializeField] private float splitFalloff = 1.8f;
+        [SerializeField] private float lodUpdateInterval = 0.25f;
+        [SerializeField] private string terrainMaterialResource = "WH30K/PlanetTerrain";
+        [SerializeField] private string saveFileName = "wh30k_vslice_save.json";
+
+        private LODPlanet planet;
+        private Material terrainMaterialInstance;
+        private NewGameMenu menu;
+        private ResourceSystem resourceSystem;
+        private EnvironmentState environmentState;
+        private ColonyEventSystem colonyEventSystem;
+        private Settlement settlement;
+        private SimpleOrbitCamera orbitCamera;
+
+        private string SavePath
+        {
+            get
+            {
+                var directory = Application.persistentDataPath;
+                if (!Directory.Exists(directory))
+                {
+                    Directory.CreateDirectory(directory);
+                }
+
+                return Path.Combine(directory, saveFileName);
+            }
+        }
+
+        private void Awake()
+        {
+            menu = GetComponent<NewGameMenu>();
+            resourceSystem = GetComponent<ResourceSystem>();
+            environmentState = GetComponent<EnvironmentState>();
+            colonyEventSystem = GetComponent<ColonyEventSystem>();
+            settlement = GetComponent<Settlement>();
+            orbitCamera = UnityEngine.Camera.main != null
+                ? UnityEngine.Camera.main.GetComponent<SimpleOrbitCamera>()
+                : null;
+
+            LoadTerrainMaterial();
+        }
+
+        private void Start()
+        {
+            if (GameSettings.HasActiveGame)
+            {
+                BeginNewGame(GameSettings.CurrentSeed, GameSettings.CurrentDifficulty);
+            }
+        }
+
+        internal void ConfigureMenu(NewGameMenu newGameMenu)
+        {
+            menu = newGameMenu;
+        }
+
+        public void BeginNewGame(int seed, GameSettings.Difficulty difficulty)
+        {
+            var definition = GameSettings.GetDefinition(difficulty);
+            GameSettings.StartNewGame(seed, difficulty);
+
+            var planetTransform = BuildPlanet(seed);
+            resourceSystem.ResetForNewGame(definition);
+            environmentState.ResetForNewGame(definition);
+
+            var random = new System.Random(seed);
+            if (!planet.TryFindLandPoint(128, random, out var settlementPosition, out var settlementNormal))
+            {
+                settlementPosition = planet.EvaluateSurfacePoint(Vector3.up);
+                settlementNormal = settlementPosition.normalized;
+            }
+
+            settlement.BeginNewGame(definition, planet, settlementPosition, settlementNormal, resourceSystem,
+                environmentState);
+            colonyEventSystem.BeginSession(definition, resourceSystem, environmentState, settlement);
+
+            menu.SetSeed(seed);
+            menu.SetDifficulty(difficulty);
+            menu.ShowNewGamePanel(false);
+            menu.ShowHud(true);
+            menu.AppendEventLog($"New colony established on seed {seed} ({definition.displayName}).");
+
+            if (orbitCamera != null)
+            {
+                orbitCamera.SetTarget(planetTransform, planetRadius);
+                orbitCamera.FrameTarget();
+            }
+        }
+
+        public void SaveToFile()
+        {
+            if (!GameSettings.HasActiveGame)
+            {
+                Debug.LogWarning("Cannot save without an active game.");
+                return;
+            }
+
+            var save = new GameSaveData
+            {
+                seed = GameSettings.CurrentSeed,
+                difficulty = GameSettings.CurrentDifficulty,
+                environment = environmentState.CreateSnapshot(),
+                resources = resourceSystem.CreateSnapshot(),
+                settlement = settlement.CreateSnapshot()
+            };
+
+            var json = JsonUtility.ToJson(save, true);
+            File.WriteAllText(SavePath, json);
+            menu.AppendEventLog("State saved to disk.");
+        }
+
+        public void LoadFromFile()
+        {
+            if (!File.Exists(SavePath))
+            {
+                Debug.LogWarning($"Save file not found at {SavePath}");
+                menu.AppendEventLog("No save file found.");
+                return;
+            }
+
+            var json = File.ReadAllText(SavePath);
+            var save = JsonUtility.FromJson<GameSaveData>(json);
+            if (save == null)
+            {
+                Debug.LogError("Failed to parse save file.");
+                return;
+            }
+
+            GameSettings.ApplyLoadedState(save.seed, save.difficulty);
+            var planetTransform = BuildPlanet(save.seed);
+
+            var definition = GameSettings.GetDefinition(save.difficulty);
+            resourceSystem.LoadFromSnapshot(save.resources, definition);
+            environmentState.LoadFromSnapshot(save.environment, definition);
+            settlement.LoadFromSnapshot(save.settlement, planet, definition, resourceSystem, environmentState);
+            colonyEventSystem.BeginSession(definition, resourceSystem, environmentState, settlement);
+
+            menu.SetSeed(save.seed);
+            menu.SetDifficulty(save.difficulty);
+            menu.ShowNewGamePanel(false);
+            menu.ShowHud(true);
+            menu.AppendEventLog("Loaded previous session.");
+
+            if (orbitCamera != null)
+            {
+                orbitCamera.SetTarget(planetTransform, planetRadius);
+                orbitCamera.FrameTarget();
+            }
+        }
+
+        private Transform BuildPlanet(int seed)
+        {
+            if (planet != null)
+            {
+                Destroy(planet.gameObject);
+            }
+
+            var planetGO = new GameObject("Planet");
+            planetGO.transform.SetParent(transform, false);
+            planet = planetGO.AddComponent<LODPlanet>();
+            planet.ApplyConfiguration(planetRadius, basePatchResolution, maximumDepth, splitDistance, splitFalloff,
+                lodUpdateInterval);
+            planet.BuildPlanet(seed, terrainMaterialInstance);
+            planet.SetCamera(UnityEngine.Camera.main);
+            return planetGO.transform;
+        }
+
+        private void LoadTerrainMaterial()
+        {
+            if (!string.IsNullOrEmpty(terrainMaterialResource))
+            {
+                var loaded = Resources.Load<Material>(terrainMaterialResource);
+                if (loaded != null)
+                {
+                    terrainMaterialInstance = Instantiate(loaded);
+                    return;
+                }
+            }
+
+            terrainMaterialInstance = new Material(Shader.Find("Standard"));
+            Debug.LogWarning("Fallback Standard shader material created for planet terrain. Resource missing?");
+        }
+
+        [Serializable]
+        private class GameSaveData
+        {
+            public int seed;
+            public GameSettings.Difficulty difficulty;
+            public EnvironmentSnapshot environment;
+            public ResourceSnapshot resources;
+            public SettlementSnapshot settlement;
+        }
+    }
+}

--- a/Assets/Scripts/Planet/PlanetBootstrap.cs.meta
+++ b/Assets/Scripts/Planet/PlanetBootstrap.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: adb3bb49a9a445a19492c33cd8777468
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Sim.meta
+++ b/Assets/Scripts/Sim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6c73b9e169fc4bb4be0c4a69e674c3e3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Sim/Buildings.meta
+++ b/Assets/Scripts/Sim/Buildings.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a98b271ee6c34505920c021a92ec9beb
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Sim/Buildings/Factory.cs
+++ b/Assets/Scripts/Sim/Buildings/Factory.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+using WH30K.Sim.Environment;
+
+namespace WH30K.Sim.Buildings
+{
+    public class Factory : SettlementBuilding
+    {
+        public override string Id => "Factory";
+        public override string DisplayName => "Macro Factory";
+        public override float PopulationCapacity => 120f;
+        public override float WorkforceSlots => 200f;
+        public override float ProductionPerWorker => 1.35f;
+        public override float UpkeepPerCycle => 32f;
+        public override EnvironmentImpact EnvironmentImpact => new EnvironmentImpact
+        {
+            co2Delta = 3.5f,
+            o2Delta = -0.25f,
+            waterDelta = 2.1f,
+            temperatureDelta = 0.18f
+        };
+        public override Color DisplayColor => new Color(0.85f, 0.45f, 0.3f);
+    }
+}

--- a/Assets/Scripts/Sim/Buildings/Factory.cs.meta
+++ b/Assets/Scripts/Sim/Buildings/Factory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1245ec8bfdaa485ab442f878b4f9c02c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Sim/Buildings/HabBlock.cs
+++ b/Assets/Scripts/Sim/Buildings/HabBlock.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+using WH30K.Sim.Environment;
+
+namespace WH30K.Sim.Buildings
+{
+    public class HabBlock : SettlementBuilding
+    {
+        public override string Id => "HabBlock";
+        public override string DisplayName => "Hab Block";
+        public override float PopulationCapacity => 320f;
+        public override float WorkforceSlots => 40f;
+        public override float ProductionPerWorker => 0.15f;
+        public override float UpkeepPerCycle => 8f;
+        public override EnvironmentImpact EnvironmentImpact => new EnvironmentImpact
+        {
+            co2Delta = 0.2f,
+            o2Delta = -0.05f,
+            waterDelta = 0.1f,
+            temperatureDelta = 0.01f
+        };
+        public override Color DisplayColor => new Color(0.8f, 0.85f, 1f);
+    }
+}

--- a/Assets/Scripts/Sim/Buildings/HabBlock.cs.meta
+++ b/Assets/Scripts/Sim/Buildings/HabBlock.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b33c246ce2f54eefbdc3a7d995048c72
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Sim/Buildings/SettlementBuilding.cs
+++ b/Assets/Scripts/Sim/Buildings/SettlementBuilding.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+using WH30K.Sim.Environment;
+
+namespace WH30K.Sim.Buildings
+{
+    /// <summary>
+    /// Base representation for a settlement building. Provides capacity, production and visual hints.
+    /// </summary>
+    public abstract class SettlementBuilding
+    {
+        public abstract string Id { get; }
+        public abstract string DisplayName { get; }
+        public abstract float PopulationCapacity { get; }
+        public abstract float WorkforceSlots { get; }
+        public abstract float ProductionPerWorker { get; }
+        public abstract float UpkeepPerCycle { get; }
+        public virtual EnvironmentImpact EnvironmentImpact => EnvironmentImpact.Zero;
+        public virtual Color DisplayColor => Color.white;
+    }
+}

--- a/Assets/Scripts/Sim/Buildings/SettlementBuilding.cs.meta
+++ b/Assets/Scripts/Sim/Buildings/SettlementBuilding.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 32bc10f1b21448449f41a98e8ad7fca9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Sim/Buildings/Utility.cs
+++ b/Assets/Scripts/Sim/Buildings/Utility.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+using WH30K.Sim.Environment;
+
+namespace WH30K.Sim.Buildings
+{
+    public class Utility : SettlementBuilding
+    {
+        public override string Id => "Utility";
+        public override string DisplayName => "Utility Nexus";
+        public override float PopulationCapacity => 90f;
+        public override float WorkforceSlots => 80f;
+        public override float ProductionPerWorker => 0.55f;
+        public override float UpkeepPerCycle => 14f;
+        public override EnvironmentImpact EnvironmentImpact => new EnvironmentImpact
+        {
+            co2Delta = 1.1f,
+            o2Delta = -0.08f,
+            waterDelta = 1f,
+            temperatureDelta = 0.05f
+        };
+        public override Color DisplayColor => new Color(0.45f, 0.75f, 0.6f);
+    }
+}

--- a/Assets/Scripts/Sim/Buildings/Utility.cs.meta
+++ b/Assets/Scripts/Sim/Buildings/Utility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: def2bdfae6f14087ba093bd60e0930da
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Sim/Environment.meta
+++ b/Assets/Scripts/Sim/Environment.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bef57b3c76324663beb4274b79eb5430
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Sim/Environment/EnvironmentState.cs
+++ b/Assets/Scripts/Sim/Environment/EnvironmentState.cs
@@ -1,0 +1,124 @@
+using System;
+using UnityEngine;
+using WH30K.Game;
+using WH30K.UI;
+
+namespace WH30K.Sim.Environment
+{
+    [Serializable]
+    public struct EnvironmentSnapshot
+    {
+        public float Co2;
+        public float O2;
+        public float WaterPollution;
+        public float GlobalTemperatureOffset;
+    }
+
+    [Serializable]
+    public struct EnvironmentImpact
+    {
+        public float co2Delta;
+        public float o2Delta;
+        public float waterDelta;
+        public float temperatureDelta;
+
+        public static EnvironmentImpact Zero => new EnvironmentImpact();
+
+        public EnvironmentImpact Scale(float factor)
+        {
+            return new EnvironmentImpact
+            {
+                co2Delta = co2Delta * factor,
+                o2Delta = o2Delta * factor,
+                waterDelta = waterDelta * factor,
+                temperatureDelta = temperatureDelta * factor
+            };
+        }
+
+        public static EnvironmentImpact operator +(EnvironmentImpact a, EnvironmentImpact b)
+        {
+            return new EnvironmentImpact
+            {
+                co2Delta = a.co2Delta + b.co2Delta,
+                o2Delta = a.o2Delta + b.o2Delta,
+                waterDelta = a.waterDelta + b.waterDelta,
+                temperatureDelta = a.temperatureDelta + b.temperatureDelta
+            };
+        }
+    }
+
+    /// <summary>
+    /// Aggregates environmental scalar values and pushes them to the HUD.
+    /// </summary>
+    public class EnvironmentState : MonoBehaviour
+    {
+        private NewGameMenu menu;
+        private GameSettings.DifficultyDefinition currentDifficulty;
+
+        private float co2;
+        private float o2;
+        private float waterPollution;
+        private float globalTempOffset;
+
+        public void ConfigureMenu(NewGameMenu newMenu)
+        {
+            menu = newMenu;
+            PushUpdate();
+        }
+
+        public void ResetForNewGame(GameSettings.DifficultyDefinition definition)
+        {
+            currentDifficulty = definition;
+            co2 = 410f * definition.environmentHarshnessMultiplier;
+            o2 = 20.8f / Mathf.Max(0.5f, definition.environmentHarshnessMultiplier * 0.85f);
+            waterPollution = 4f * definition.environmentHarshnessMultiplier;
+            globalTempOffset = 0f;
+            PushUpdate();
+        }
+
+        public void ApplyIndustryImpact(EnvironmentImpact impact, float deltaTime)
+        {
+            var harshness = currentDifficulty.environmentHarshnessMultiplier;
+            co2 = Mathf.Max(0f, co2 + impact.co2Delta * deltaTime * harshness);
+            o2 = Mathf.Max(0f, o2 + impact.o2Delta * deltaTime * 0.5f);
+            waterPollution = Mathf.Max(0f, waterPollution + impact.waterDelta * deltaTime * harshness);
+            globalTempOffset += impact.temperatureDelta * deltaTime * 0.5f;
+            PushUpdate();
+        }
+
+        public void ApplyImmediateImpact(EnvironmentImpact impact)
+        {
+            co2 = Mathf.Max(0f, co2 + impact.co2Delta);
+            o2 = Mathf.Max(0f, o2 + impact.o2Delta);
+            waterPollution = Mathf.Max(0f, waterPollution + impact.waterDelta);
+            globalTempOffset += impact.temperatureDelta;
+            PushUpdate();
+        }
+
+        public EnvironmentSnapshot CreateSnapshot()
+        {
+            return new EnvironmentSnapshot
+            {
+                Co2 = co2,
+                O2 = o2,
+                WaterPollution = waterPollution,
+                GlobalTemperatureOffset = globalTempOffset
+            };
+        }
+
+        public void LoadFromSnapshot(EnvironmentSnapshot snapshot, GameSettings.DifficultyDefinition definition)
+        {
+            currentDifficulty = definition;
+            co2 = snapshot.Co2;
+            o2 = snapshot.O2;
+            waterPollution = snapshot.WaterPollution;
+            globalTempOffset = snapshot.GlobalTemperatureOffset;
+            PushUpdate();
+        }
+
+        private void PushUpdate()
+        {
+            menu?.UpdateEnvironmentReadout(CreateSnapshot());
+        }
+    }
+}

--- a/Assets/Scripts/Sim/Environment/EnvironmentState.cs.meta
+++ b/Assets/Scripts/Sim/Environment/EnvironmentState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 456145cf744b449380d1d7ab52666796
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Sim/Events.meta
+++ b/Assets/Scripts/Sim/Events.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 19d4d89c99c14eefad18b949b352e143
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Sim/Events/EventSystem.cs
+++ b/Assets/Scripts/Sim/Events/EventSystem.cs
@@ -1,0 +1,93 @@
+using System.Collections;
+using UnityEngine;
+using WH30K.Game;
+using WH30K.Sim.Environment;
+using WH30K.Sim.Resources;
+using WH30K.Sim.Settlements;
+using WH30K.UI;
+
+namespace WH30K.Sim.Events
+{
+    /// <summary>
+    /// Lightweight event driver that surfaces narrative choices and applies their systemic impacts.
+    /// </summary>
+    public class ColonyEventSystem : MonoBehaviour
+    {
+        private NewGameMenu menu;
+        private ResourceSystem resourceSystem;
+        private EnvironmentState environmentState;
+        private Settlement settlement;
+        private GameSettings.DifficultyDefinition difficulty;
+        private Coroutine eventCoroutine;
+
+        public void ConfigureMenu(NewGameMenu newMenu)
+        {
+            menu = newMenu;
+        }
+
+        public void BeginSession(GameSettings.DifficultyDefinition definition, ResourceSystem resources,
+            EnvironmentState environment, Settlement settlementInstance)
+        {
+            difficulty = definition;
+            resourceSystem = resources;
+            environmentState = environment;
+            settlement = settlementInstance;
+
+            if (eventCoroutine != null)
+            {
+                StopCoroutine(eventCoroutine);
+            }
+
+            eventCoroutine = StartCoroutine(EventRoutine());
+        }
+
+        private IEnumerator EventRoutine()
+        {
+            var delay = Mathf.Lerp(18f, 45f, Random.value);
+            delay /= Mathf.Max(0.25f, difficulty.eventFrequencyMultiplier);
+            yield return new WaitForSeconds(delay);
+            TriggerIndustrialPolicyEvent();
+            eventCoroutine = null;
+        }
+
+        private void TriggerIndustrialPolicyEvent()
+        {
+            const string title = "Industrial Priorities";
+            var body = "Factory prefects demand higher output while the air scrubbers struggle to keep pace. " +
+                       "Will you divert resources to safety retrofits or order the furnaces to burn hotter?";
+
+            var safetyOption = "Fund safety retrofits (-Stockpile, -Production, cleaner air)";
+            var overdriveOption = "Overclock furnaces (+Stockpile, +Production, harsher environment)";
+
+            menu?.PromptEvent(title, body, safetyOption, OnSafetyChosen, overdriveOption, OnOverdriveChosen);
+        }
+
+        private void OnSafetyChosen()
+        {
+            resourceSystem.ModifyStockpile(-60f * resourceSystem.ResourceYieldMultiplier);
+            settlement.AdjustPolicy(-0.08f, -0.05f, null);
+            environmentState.ApplyImmediateImpact(new EnvironmentImpact
+            {
+                co2Delta = -7f,
+                o2Delta = 0.35f,
+                waterDelta = -2.5f,
+                temperatureDelta = -0.04f
+            });
+            menu?.AppendEventLog("Mandated safety upgrades across the industrial sector.");
+        }
+
+        private void OnOverdriveChosen()
+        {
+            resourceSystem.ModifyStockpile(45f * resourceSystem.ResourceYieldMultiplier);
+            settlement.AdjustPolicy(0.12f, 0.08f, null);
+            environmentState.ApplyImmediateImpact(new EnvironmentImpact
+            {
+                co2Delta = 10f,
+                o2Delta = -0.4f,
+                waterDelta = 4f,
+                temperatureDelta = 0.09f
+            });
+            menu?.AppendEventLog("Ordered furnaces into overdrive to meet production quotas.");
+        }
+    }
+}

--- a/Assets/Scripts/Sim/Events/EventSystem.cs.meta
+++ b/Assets/Scripts/Sim/Events/EventSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 63e1953627164b42865b4b70cf5bfd69
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Sim/Resources.meta
+++ b/Assets/Scripts/Sim/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d7408930e90e45a5852e9c14867ca5f7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Sim/Resources/ResourceSystem.cs
+++ b/Assets/Scripts/Sim/Resources/ResourceSystem.cs
@@ -1,0 +1,101 @@
+using System;
+using UnityEngine;
+using WH30K.Game;
+using WH30K.Sim.Settlements;
+using WH30K.UI;
+
+namespace WH30K.Sim.Resources
+{
+    [Serializable]
+    public struct ResourceSnapshot
+    {
+        public float Population;
+        public float Workforce;
+        public float ProductionPerCycle;
+        public float UpkeepPerCycle;
+        public float NetProduction;
+        public float Stockpile;
+    }
+
+    /// <summary>
+    /// Tracks resource stockpiles and exposes a simple interface for the settlement simulation.
+    /// </summary>
+    public class ResourceSystem : MonoBehaviour
+    {
+        private NewGameMenu menu;
+        private float stockpile;
+        private float population;
+        private float workforce;
+        private float productionPerCycle;
+        private float upkeepPerCycle;
+        private float netProduction;
+        private GameSettings.DifficultyDefinition currentDifficulty;
+
+        public float ResourceYieldMultiplier => currentDifficulty.resourceYieldMultiplier;
+
+        public void ConfigureMenu(NewGameMenu newMenu)
+        {
+            menu = newMenu;
+            PushUpdate();
+        }
+
+        public void ResetForNewGame(GameSettings.DifficultyDefinition definition)
+        {
+            currentDifficulty = definition;
+            stockpile = 500f * definition.resourceYieldMultiplier;
+            population = 0f;
+            workforce = 0f;
+            productionPerCycle = 0f;
+            upkeepPerCycle = 0f;
+            netProduction = 0f;
+            PushUpdate();
+        }
+
+        public void ApplySettlementReport(SettlementReport report)
+        {
+            population = report.population;
+            workforce = report.workforce;
+            productionPerCycle = report.production;
+            upkeepPerCycle = report.upkeep;
+            netProduction = report.net;
+            stockpile = Mathf.Max(0f, stockpile + report.net * report.tickInterval);
+            PushUpdate();
+        }
+
+        public void ModifyStockpile(float delta)
+        {
+            stockpile = Mathf.Max(0f, stockpile + delta);
+            PushUpdate();
+        }
+
+        public ResourceSnapshot CreateSnapshot()
+        {
+            return new ResourceSnapshot
+            {
+                Population = population,
+                Workforce = workforce,
+                ProductionPerCycle = productionPerCycle,
+                UpkeepPerCycle = upkeepPerCycle,
+                NetProduction = netProduction,
+                Stockpile = stockpile
+            };
+        }
+
+        public void LoadFromSnapshot(ResourceSnapshot snapshot, GameSettings.DifficultyDefinition definition)
+        {
+            currentDifficulty = definition;
+            population = snapshot.Population;
+            workforce = snapshot.Workforce;
+            productionPerCycle = snapshot.ProductionPerCycle;
+            upkeepPerCycle = snapshot.UpkeepPerCycle;
+            netProduction = snapshot.NetProduction;
+            stockpile = snapshot.Stockpile;
+            PushUpdate();
+        }
+
+        private void PushUpdate()
+        {
+            menu?.UpdateResourceReadout(CreateSnapshot());
+        }
+    }
+}

--- a/Assets/Scripts/Sim/Resources/ResourceSystem.cs.meta
+++ b/Assets/Scripts/Sim/Resources/ResourceSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a55235ece2394358badf2a2e8baddd55
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Sim/Settlement.cs
+++ b/Assets/Scripts/Sim/Settlement.cs
@@ -1,0 +1,313 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using WH30K.Game;
+using WH30K.Planet;
+using WH30K.Sim.Buildings;
+using WH30K.Sim.Environment;
+using WH30K.Sim.Resources;
+using WH30K.UI;
+
+namespace WH30K.Sim.Settlements
+{
+    [Serializable]
+    public struct SettlementSnapshot
+    {
+        public float population;
+        public float workforce;
+        public float productionModifier;
+        public float upkeepModifier;
+        public Vector3 position;
+        public Vector3 normal;
+        public string[] buildings;
+    }
+
+    public struct SettlementReport
+    {
+        public float population;
+        public float workforce;
+        public float production;
+        public float upkeep;
+        public float net;
+        public float tickInterval;
+    }
+
+    /// <summary>
+    /// Handles the initial settlement, building instantiation, and the lightweight resource loop.
+    /// </summary>
+    public class Settlement : MonoBehaviour
+    {
+        [SerializeField] private float tickInterval = 1f;
+        [SerializeField] private float populationGrowthRate = 0.05f;
+        [SerializeField] private float workforceRatio = 0.62f;
+        [SerializeField] private float buildingSpacing = 220f;
+
+        private readonly List<SettlementBuilding> buildings = new List<SettlementBuilding>();
+        private readonly List<GameObject> buildingVisuals = new List<GameObject>();
+        private static readonly Dictionary<Color, Material> MaterialCache = new Dictionary<Color, Material>();
+
+        private LODPlanet planet;
+        private ResourceSystem resourceSystem;
+        private EnvironmentState environmentState;
+        private NewGameMenu menu;
+        private Transform settlementAnchor;
+        private GameSettings.DifficultyDefinition currentDifficulty;
+
+        private float population;
+        private float workforce;
+        private float productionModifier = 1f;
+        private float upkeepModifier = 1f;
+        private float tickTimer;
+        private Vector3 storedPosition;
+        private Vector3 storedNormal;
+
+        public void ConfigureMenu(NewGameMenu newMenu)
+        {
+            menu = newMenu;
+        }
+
+        public void BeginNewGame(GameSettings.DifficultyDefinition definition, LODPlanet planetInstance,
+            Vector3 surfacePosition, Vector3 surfaceNormal, ResourceSystem resources, EnvironmentState environment)
+        {
+            currentDifficulty = definition;
+            planet = planetInstance;
+            resourceSystem = resources;
+            environmentState = environment;
+            productionModifier = definition.resourceYieldMultiplier;
+            upkeepModifier = Mathf.Lerp(1f, 1.3f, Mathf.InverseLerp(1f, 1.4f, definition.environmentHarshnessMultiplier));
+            population = Mathf.Max(120f, 160f * definition.resourceYieldMultiplier);
+            workforce = population * workforceRatio;
+            tickTimer = 0f;
+            storedPosition = surfacePosition;
+            storedNormal = surfaceNormal;
+
+            ClearVisuals();
+            EnsureAnchor(surfacePosition, surfaceNormal);
+            RebuildBuildings(new[] { "HabBlock", "Factory", "Utility" });
+            menu?.AppendEventLog("Settlement core deployed on new world.");
+        }
+
+        public void LoadFromSnapshot(SettlementSnapshot snapshot, LODPlanet planetInstance,
+            GameSettings.DifficultyDefinition definition, ResourceSystem resources, EnvironmentState environment)
+        {
+            currentDifficulty = definition;
+            planet = planetInstance;
+            resourceSystem = resources;
+            environmentState = environment;
+            productionModifier = snapshot.productionModifier;
+            upkeepModifier = snapshot.upkeepModifier;
+            population = snapshot.population;
+            workforce = snapshot.workforce;
+            tickTimer = 0f;
+            storedPosition = snapshot.position;
+            storedNormal = snapshot.normal.sqrMagnitude > 0.01f ? snapshot.normal.normalized : snapshot.position.normalized;
+
+            ClearVisuals();
+            EnsureAnchor(storedPosition, storedNormal);
+            RebuildBuildings(snapshot.buildings != null && snapshot.buildings.Length > 0
+                ? snapshot.buildings
+                : new[] { "HabBlock", "Factory", "Utility" });
+        }
+
+        private void Update()
+        {
+            if (planet == null || resourceSystem == null || environmentState == null)
+            {
+                return;
+            }
+
+            tickTimer += Time.deltaTime;
+            if (tickTimer < tickInterval)
+            {
+                return;
+            }
+
+            tickTimer -= tickInterval;
+            RunTick();
+        }
+
+        public SettlementSnapshot CreateSnapshot()
+        {
+            var ids = new string[buildings.Count];
+            for (var i = 0; i < buildings.Count; i++)
+            {
+                ids[i] = buildings[i].Id;
+            }
+
+            return new SettlementSnapshot
+            {
+                population = population,
+                workforce = workforce,
+                productionModifier = productionModifier,
+                upkeepModifier = upkeepModifier,
+                position = storedPosition,
+                normal = storedNormal,
+                buildings = ids
+            };
+        }
+
+        public void AdjustPolicy(float productionDelta, float upkeepDelta, string message)
+        {
+            productionModifier = Mathf.Clamp(productionModifier + productionDelta, 0.25f, 3f);
+            upkeepModifier = Mathf.Clamp(upkeepModifier + upkeepDelta, 0.1f, 3f);
+            if (!string.IsNullOrEmpty(message))
+            {
+                menu?.AppendEventLog(message);
+            }
+        }
+
+        private void RunTick()
+        {
+            var capacity = 0f;
+            var workforceCapacity = 0f;
+            foreach (var building in buildings)
+            {
+                capacity += building.PopulationCapacity;
+                workforceCapacity += building.WorkforceSlots;
+            }
+
+            var growthTarget = Mathf.Min(capacity, population + (capacity - population) * populationGrowthRate);
+            population = Mathf.MoveTowards(population, growthTarget, populationGrowthRate * capacity * tickInterval);
+            workforce = Mathf.Min(workforceCapacity, population * workforceRatio);
+
+            var availableWorkers = workforce;
+            var production = 0f;
+            var upkeep = 0f;
+            var totalImpact = EnvironmentImpact.Zero;
+
+            foreach (var building in buildings)
+            {
+                var assigned = Mathf.Min(building.WorkforceSlots, availableWorkers);
+                availableWorkers -= assigned;
+                production += assigned * building.ProductionPerWorker;
+                upkeep += building.UpkeepPerCycle;
+                if (building.WorkforceSlots > 0f)
+                {
+                    var utilisation = assigned / Mathf.Max(1f, building.WorkforceSlots);
+                    totalImpact += building.EnvironmentImpact.Scale(utilisation);
+                }
+            }
+
+            production *= productionModifier;
+            upkeep *= upkeepModifier;
+            var net = production - upkeep;
+
+            resourceSystem.ApplySettlementReport(new SettlementReport
+            {
+                population = population,
+                workforce = workforce,
+                production = production,
+                upkeep = upkeep,
+                net = net,
+                tickInterval = tickInterval
+            });
+
+            environmentState.ApplyIndustryImpact(totalImpact, tickInterval);
+        }
+
+        private void RebuildBuildings(IEnumerable<string> buildingIds)
+        {
+            buildings.Clear();
+            foreach (var id in buildingIds)
+            {
+                var building = CreateBuilding(id);
+                if (building != null)
+                {
+                    buildings.Add(building);
+                }
+            }
+
+            if (buildings.Count == 0)
+            {
+                buildings.Add(new HabBlock());
+                buildings.Add(new Factory());
+                buildings.Add(new Utility());
+            }
+
+            SpawnVisuals();
+        }
+
+        private SettlementBuilding CreateBuilding(string id)
+        {
+            switch (id)
+            {
+                case "HabBlock":
+                    return new HabBlock();
+                case "Factory":
+                    return new Factory();
+                case "Utility":
+                    return new Utility();
+                default:
+                    Debug.LogWarning($"Unknown building id '{id}', defaulting to Hab Block.");
+                    return new HabBlock();
+            }
+        }
+
+        private void SpawnVisuals()
+        {
+            ClearVisuals();
+            if (settlementAnchor == null)
+            {
+                return;
+            }
+
+            var count = buildings.Count;
+            for (var i = 0; i < count; i++)
+            {
+                var building = buildings[i];
+                var visual = GameObject.CreatePrimitive(PrimitiveType.Cube);
+                visual.name = building.DisplayName;
+                visual.transform.SetParent(settlementAnchor, false);
+                visual.transform.localScale = new Vector3(120f, 160f, 120f);
+                var angle = (Mathf.PI * 2f / Mathf.Max(1, count)) * i;
+                var offset = new Vector3(Mathf.Cos(angle), 0f, Mathf.Sin(angle)) * buildingSpacing;
+                visual.transform.localPosition = offset + Vector3.up * 80f;
+                var collider = visual.GetComponent<Collider>();
+                if (collider != null)
+                {
+                    Destroy(collider);
+                }
+                var renderer = visual.GetComponent<MeshRenderer>();
+                renderer.sharedMaterial = GetMaterial(building.DisplayColor);
+                buildingVisuals.Add(visual);
+            }
+        }
+
+        private void ClearVisuals()
+        {
+            foreach (var visual in buildingVisuals)
+            {
+                if (visual != null)
+                {
+                    Destroy(visual);
+                }
+            }
+
+            buildingVisuals.Clear();
+        }
+
+        private void EnsureAnchor(Vector3 position, Vector3 normal)
+        {
+            if (settlementAnchor == null)
+            {
+                var anchorGO = new GameObject("SettlementAnchor");
+                settlementAnchor = anchorGO.transform;
+            }
+
+            settlementAnchor.SetParent(planet.transform, false);
+            settlementAnchor.position = position;
+            settlementAnchor.rotation = Quaternion.FromToRotation(Vector3.up, normal.normalized);
+        }
+
+        private static Material GetMaterial(Color color)
+        {
+            if (!MaterialCache.TryGetValue(color, out var material) || material == null)
+            {
+                material = new Material(Shader.Find("Standard")) { color = color };
+                MaterialCache[color] = material;
+            }
+
+            return material;
+        }
+    }
+}

--- a/Assets/Scripts/Sim/Settlement.cs.meta
+++ b/Assets/Scripts/Sim/Settlement.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 467311dff0604dfe861e13bcda9f11bb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Shaders.meta
+++ b/Assets/Shaders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e8303e55ff514371a0a1905169b459cc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Shaders/PlanetRockDirtTriplanar_BuiltIn.shader
+++ b/Assets/Shaders/PlanetRockDirtTriplanar_BuiltIn.shader
@@ -1,0 +1,97 @@
+Shader "WH30K/PlanetRockDirtTriplanar_BuiltIn"
+{
+    Properties
+    {
+        _RockColor ("Rock Color", Color) = (0.45, 0.43, 0.4, 1)
+        _DirtColor ("Dirt Color", Color) = (0.36, 0.25, 0.15, 1)
+        _TextureScale ("Noise Scale", Float) = 500.0
+        _NoiseIntensity ("Noise Intensity", Range(0, 1)) = 0.35
+        _BlendSharpness ("Blend Sharpness", Range(1, 8)) = 4
+    }
+    SubShader
+    {
+        Tags { "RenderType" = "Opaque" }
+        LOD 300
+
+        Pass
+        {
+            Tags { "LightMode" = "ForwardBase" }
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #include "UnityCG.cginc"
+
+            fixed4 _RockColor;
+            fixed4 _DirtColor;
+            float _TextureScale;
+            float _NoiseIntensity;
+            float _BlendSharpness;
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float3 normal : NORMAL;
+            };
+
+            struct v2f
+            {
+                float4 pos : SV_POSITION;
+                float3 worldPos : TEXCOORD0;
+                float3 worldNormal : TEXCOORD1;
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                o.pos = UnityObjectToClipPos(v.vertex);
+                o.worldPos = mul(unity_ObjectToWorld, v.vertex).xyz;
+                o.worldNormal = UnityObjectToWorldNormal(v.normal);
+                return o;
+            }
+
+            float Hash21(float2 p)
+            {
+                float3 p3 = frac(float3(p.xyx) * 0.1031);
+                p3 += dot(p3, p3.yzx + 33.33);
+                return frac((p3.x + p3.y) * p3.z);
+            }
+
+            float SampleTriplanarNoise(float3 worldPos, float3 blendWeights, float scale)
+            {
+                float safeScale = max(0.0001, scale);
+                float3 scaledPos = worldPos / safeScale;
+                float xSample = Hash21(scaledPos.yz);
+                float ySample = Hash21(scaledPos.xz);
+                float zSample = Hash21(scaledPos.xy);
+                return dot(float3(xSample, ySample, zSample), blendWeights);
+            }
+
+            float NoiseVariation(float noiseValue)
+            {
+                float centered = (noiseValue - 0.5) * 2.0;
+                return 1.0 + centered * _NoiseIntensity;
+            }
+
+            fixed4 frag(v2f i) : SV_Target
+            {
+                float3 normal = normalize(i.worldNormal);
+                float3 blend = pow(abs(normal), _BlendSharpness);
+                blend = blend / (blend.x + blend.y + blend.z + 1e-5);
+
+                float rockNoise = SampleTriplanarNoise(i.worldPos + 173.0, blend, _TextureScale * 0.75);
+                float dirtNoise = SampleTriplanarNoise(i.worldPos, blend, _TextureScale);
+
+                float3 rock = _RockColor.rgb * NoiseVariation(rockNoise);
+                float3 dirt = _DirtColor.rgb * NoiseVariation(dirtNoise);
+
+                float slope = saturate(1.0 - abs(normal.y));
+                float heightFactor = saturate((i.worldPos.y + 1000.0) / 2000.0);
+                float rockBlend = saturate(slope * 1.5 + heightFactor * 0.5);
+                float3 albedo = lerp(dirt, rock, rockBlend);
+
+                return fixed4(saturate(albedo), 1.0);
+            }
+            ENDCG
+        }
+    }
+}

--- a/Assets/Shaders/PlanetRockDirtTriplanar_BuiltIn.shader.meta
+++ b/Assets/Shaders/PlanetRockDirtTriplanar_BuiltIn.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: a018cfe441804ffbb774bb799d920597
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorDefines: []
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Docs.meta
+++ b/Docs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cc5e86df82ad4aba94ffc003bc418515
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Docs/README_VS01.md
+++ b/Docs/README_VS01.md
@@ -1,0 +1,31 @@
+# WH30K Vertical Slice 0.1
+
+This scene demonstrates the first playable vertical slice of the WH30K colony builder. It lives in `Assets/Scenes/Prototype/WH30K_VS01.unity` and targets the built-in render pipeline.
+
+## Feature Overview
+
+- **Procedural planet** – a cube-sphere LOD planet (radius ~3000) with deterministic noise driven by the selected seed. LOD updates are throttled and degrade with distance to keep updates smooth.
+- **Single shared terrain material** – the `WH30K/PlanetRockDirtTriplanar_BuiltIn` shader procedurally blends rock and dirt color bands with triplanar noise to avoid seams.
+- **Orbit camera** – right mouse button to orbit, scroll to zoom. Press `Home` or `F` to re-frame the planet.
+- **New game panel** – enter a numeric seed (blank = random) and cycle through difficulties (Easy → Grim). Difficulty changes resource yield, environment harshness, and event cadence.
+- **Settlement loop** – a single starting settlement spawns on land with Hab Block, Macro Factory, and Utility Nexus buildings. Population, workforce, production, upkeep and stockpile totals are tracked via the HUD.
+- **Environment scalars** – CO₂, O₂, water pollution, and global temperature offset respond to industry output and are always visible on the HUD.
+- **Narrative event** – within the first minute an "Industrial Priorities" decision appears. Each option alters the settlement multipliers, resources, and environment while logging the outcome.
+- **Saving & loading** – `Save` writes JSON to the persistent data path, `Load` restores the seed, difficulty, settlement state, and environment scalars.
+
+## Controls
+
+| Action | Input |
+| --- | --- |
+| Orbit | Right Mouse Drag |
+| Zoom | Mouse Scroll Wheel |
+| Re-frame planet | `Home` or `F` |
+| Start new game | `Begin` button |
+| Save / Load | Buttons on the new game panel |
+
+## Implementation Notes
+
+- `PlanetBootstrap` owns the session lifecycle (planet generation, settlement spawn, event driver, save/load).
+- `NewGameMenu` builds the entire UI at runtime so the scene stays lightweight.
+- Resource and environment systems push data to the HUD after every tick for instant feedback.
+- Save files are stored at `Application.persistentDataPath/wh30k_vslice_save.json`.


### PR DESCRIPTION
## Summary
- replace the rock/dirt texture sampling with a procedural triplanar shader so no binary textures are required
- update the planet terrain material to drive the new color and noise properties and document the change

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68d263aa6eac832296e923cb76bdbe62