### PR TITLE
Enhance planet LOD detail and biome shading

### DIFF
--- a/Assets/Resources/WH30K/PlanetTerrain.mat
+++ b/Assets/Resources/WH30K/PlanetTerrain.mat
@@ -23,7 +23,18 @@ Material:
     - _BlendSharpness: 4
     - _NoiseIntensity: 0.35
     - _TextureScale: 500
+    - _BiomeNoiseScale: 850
+    - _BiomeContrast: 1.2
+    - _CoastBlend: 120
+    - _SnowLine: 600
+    - _PlanetRadius: 3000
+    - _SeaLevel: 2880
     m_Colors:
     - _DirtColor: {r: 0.36, g: 0.25, b: 0.15, a: 1}
     - _RockColor: {r: 0.45, g: 0.43, b: 0.4, a: 1}
+    - _GrassColor: {r: 0.28, g: 0.46, b: 0.24, a: 1}
+    - _DesertColor: {r: 0.86, g: 0.74, b: 0.5, a: 1}
+    - _SnowColor: {r: 0.92, g: 0.95, b: 0.98, a: 1}
+    - _OceanShallowColor: {r: 0.12, g: 0.4, b: 0.55, a: 1}
+    - _OceanDeepColor: {r: 0.02, g: 0.08, b: 0.2, a: 1}
   m_BuildTextureStacks: []

--- a/Assets/Scripts/Planet/PlanetBootstrap.cs
+++ b/Assets/Scripts/Planet/PlanetBootstrap.cs
@@ -24,8 +24,10 @@ namespace WH30K.Gameplay
     {
         [Header("Planet")]
         [SerializeField] private float planetRadius = 3000f;
-        [SerializeField] private int basePatchResolution = 48;
-        [SerializeField] private int maximumDepth = 5;
+        [SerializeField] private int basePatchResolution = 32;
+        [SerializeField] private int maximumDepth = 6;
+        [SerializeField] private int maxPatchResolution = 1024;
+        [SerializeField] private float targetTriangleArea = 10f;
         [SerializeField] private float splitDistance = 2400f;
         [SerializeField] private float splitFalloff = 1.8f;
         [SerializeField] private float lodUpdateInterval = 0.25f;
@@ -194,7 +196,7 @@ namespace WH30K.Gameplay
             planetGO.transform.SetParent(transform, false);
             planet = planetGO.AddComponent<LODPlanet>();
             planet.ApplyConfiguration(planetRadius, basePatchResolution, maximumDepth, splitDistance, splitFalloff,
-                lodUpdateInterval);
+                lodUpdateInterval, maxPatchResolution, targetTriangleArea);
             planet.BuildPlanet(seed, terrainMaterialInstance);
             planet.SetCamera(UnityEngine.Camera.main);
             return planetGO.transform;


### PR DESCRIPTION
## Summary
- increase the cube-sphere LOD system to scale resolution per depth, enforcing a 10 m² detail target and updating material parameters automatically
- expose new bootstrap configuration for maximum patch resolution and target triangle area so runtime settings can ensure the requested fidelity
- expand the triplanar shader and material with biome-aware land colors and depth-based ocean colouring for more realistic regional variation

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68d2a9b7df54832292e6a084d71167cc