### PR TITLE
Ensure LOD patch resolution caps stay above defaults

### DIFF
--- a/Assets/Scripts/Planet/LODPlanet.cs
+++ b/Assets/Scripts/Planet/LODPlanet.cs
@@ -79,13 +79,18 @@ namespace WH30K.Planet
             }
         }
 
+        private const int DefaultPatchResolutionCap = 1024;
+
         public void ApplyConfiguration(float targetRadius, int baseRes, int depthLimit, float distance, float falloff,
             float updateInterval, int patchResolutionCap, float desiredTriangleArea)
         {
             radius = Mathf.Max(100f, targetRadius);
             baseResolution = Mathf.Max(8, baseRes);
             maxDepth = Mathf.Max(0, depthLimit);
-            maxPatchResolution = Mathf.Max(baseResolution, patchResolutionCap);
+            var effectivePatchCap = patchResolutionCap <= baseResolution
+                ? DefaultPatchResolutionCap
+                : patchResolutionCap;
+            maxPatchResolution = Mathf.Max(baseResolution, effectivePatchCap);
             targetTriangleArea = Mathf.Max(0.5f, desiredTriangleArea);
             splitDistance = Mathf.Max(radius * 0.2f, distance);
             splitFalloff = Mathf.Max(1.01f, falloff);

--- a/Assets/Scripts/Planet/PlanetBootstrap.cs
+++ b/Assets/Scripts/Planet/PlanetBootstrap.cs
@@ -43,6 +43,8 @@ namespace WH30K.Gameplay
         private Settlement settlement;
         private SimpleOrbitCamera orbitCamera;
 
+        private const int DefaultMaxPatchResolution = 1024;
+
         private string SavePath
         {
             get
@@ -59,6 +61,8 @@ namespace WH30K.Gameplay
 
         private void Awake()
         {
+            EnforcePatchResolutionCap();
+
             menu = GetComponent<NewGameMenu>();
             resourceSystem = GetComponent<ResourceSystem>();
             environmentState = GetComponent<EnvironmentState>();
@@ -69,6 +73,19 @@ namespace WH30K.Gameplay
                 : null;
 
             LoadTerrainMaterial();
+        }
+
+        private void OnValidate()
+        {
+            EnforcePatchResolutionCap();
+        }
+
+        private void EnforcePatchResolutionCap()
+        {
+            if (maxPatchResolution < DefaultMaxPatchResolution)
+            {
+                maxPatchResolution = DefaultMaxPatchResolution;
+            }
         }
 
         private void Start()


### PR DESCRIPTION
## Summary
- clamp the serialized bootstrap patch resolution cap to the intended default before configuration
- fall back to the default patch resolution cap inside LODPlanet when configuration supplies a too-low value

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68d2b513ac548322a3e3a69771e1eee8