### PR TITLE
Add in-game panel for surface marker controls

### DIFF
--- a/Assets/Scripts/Game/NewGameMenu.cs
+++ b/Assets/Scripts/Game/NewGameMenu.cs
@@ -24,6 +24,7 @@ namespace WH30K.UI
         private const float PanelWidth = 320f;
         private const float PanelHeight = 210f;
         private const float HudPanelWidth = 260f;
+        private const float DebugPanelHeight = 400f;
 
         private PlanetBootstrap bootstrap;
         private ResourceSystem resourceSystem;
@@ -50,6 +51,21 @@ namespace WH30K.UI
         private Text eventChoiceBLabel;
         private Button eventChoiceAButton;
         private Button eventChoiceBButton;
+
+        private GameObject debugPanel;
+        private Toggle spawnMarkersToggle;
+        private Slider markerCountSlider;
+        private Text markerCountValueLabel;
+        private Slider markerScaleSlider;
+        private Text markerScaleValueLabel;
+        private Slider markerRedSlider;
+        private Slider markerGreenSlider;
+        private Slider markerBlueSlider;
+        private Text markerRedValueLabel;
+        private Text markerGreenValueLabel;
+        private Text markerBlueValueLabel;
+        private Button regenerateMarkersButton;
+        private bool suppressDebugControlCallbacks;
 
         private readonly List<string> eventLogEntries = new List<string>();
         private GameSettings.Difficulty selectedDifficulty = GameSettings.Difficulty.Standard;
@@ -106,6 +122,7 @@ namespace WH30K.UI
             canvasGO.AddComponent<GraphicRaycaster>();
 
             BuildNewGamePanel(canvas.transform);
+            BuildDebugPanel(canvas.transform);
             BuildHudPanel(canvas.transform);
             BuildEventPanel(canvas.transform);
         }
@@ -150,6 +167,63 @@ namespace WH30K.UI
             loadButton = CreateButton("LoadButton", newGamePanel.transform,
                 new Vector2((PanelWidth * 0.5f) + 5f, -150f), "Load", out _, (PanelWidth - 50f) * 0.5f);
             loadButton.onClick.AddListener(OnLoadClicked);
+        }
+
+        private void BuildDebugPanel(Transform parent)
+        {
+            debugPanel = CreatePanel("DebugPanel", parent, new Vector2(PanelWidth, DebugPanelHeight),
+                new Vector2(10f, -(PanelHeight + 20f)), TextAnchor.UpperLeft);
+
+            CreateLabel("DebugTitle", debugPanel.transform, "Surface Markers", 18, TextAnchor.UpperLeft,
+                new Vector2(0f, -10f), PanelWidth - 30f, 24f);
+
+            spawnMarkersToggle = CreateToggle("SpawnMarkersToggle", debugPanel.transform, new Vector2(0f, -50f),
+                "Show debug markers");
+            spawnMarkersToggle.onValueChanged.AddListener(OnSpawnMarkersToggleChanged);
+
+            CreateLabel("MarkerCountLabel", debugPanel.transform, "Marker count", 14, TextAnchor.UpperLeft,
+                new Vector2(0f, -90f), PanelWidth - 30f, 20f);
+            markerCountValueLabel = CreateLabel("MarkerCountValue", debugPanel.transform, "0", 14, TextAnchor.MiddleRight,
+                new Vector2(PanelWidth - 70f, -90f), 60f, 20f);
+            markerCountSlider = CreateSlider("MarkerCountSlider", debugPanel.transform, new Vector2(0f, -120f),
+                PanelWidth - 40f);
+            markerCountSlider.minValue = 0f;
+            markerCountSlider.maxValue = 64f;
+            markerCountSlider.wholeNumbers = true;
+            markerCountSlider.onValueChanged.AddListener(OnMarkerCountSliderChanged);
+
+            CreateLabel("MarkerScaleLabel", debugPanel.transform, "Marker scale", 14, TextAnchor.UpperLeft,
+                new Vector2(0f, -160f), PanelWidth - 30f, 20f);
+            markerScaleValueLabel = CreateLabel("MarkerScaleValue", debugPanel.transform, "0", 14, TextAnchor.MiddleRight,
+                new Vector2(PanelWidth - 70f, -160f), 60f, 20f);
+            markerScaleSlider = CreateSlider("MarkerScaleSlider", debugPanel.transform, new Vector2(0f, -190f),
+                PanelWidth - 40f);
+            markerScaleSlider.minValue = 5f;
+            markerScaleSlider.maxValue = 150f;
+            markerScaleSlider.wholeNumbers = false;
+            markerScaleSlider.value = markerScaleSlider.minValue;
+            markerScaleSlider.onValueChanged.AddListener(OnMarkerScaleSliderChanged);
+
+            CreateLabel("MarkerColorLabel", debugPanel.transform, "Marker color", 14, TextAnchor.UpperLeft,
+                new Vector2(0f, -230f), PanelWidth - 30f, 20f);
+            markerRedSlider = CreateColorSlider("MarkerColorRSlider", debugPanel.transform, new Vector2(30f, -260f),
+                out markerRedValueLabel, "R");
+            markerGreenSlider = CreateColorSlider("MarkerColorGSlider", debugPanel.transform,
+                new Vector2(30f, -290f), out markerGreenValueLabel, "G");
+            markerBlueSlider = CreateColorSlider("MarkerColorBSlider", debugPanel.transform, new Vector2(30f, -320f),
+                out markerBlueValueLabel, "B");
+            markerRedSlider.onValueChanged.AddListener(OnMarkerColorSliderChanged);
+            markerGreenSlider.onValueChanged.AddListener(OnMarkerColorSliderChanged);
+            markerBlueSlider.onValueChanged.AddListener(OnMarkerColorSliderChanged);
+
+            regenerateMarkersButton = CreateButton("RegenerateMarkersButton", debugPanel.transform,
+                new Vector2(0f, -360f), "Respawn markers", out _, PanelWidth - 40f);
+            regenerateMarkersButton.onClick.AddListener(OnRegenerateMarkersClicked);
+
+            UpdateMarkerCountLabel(markerCountSlider.value);
+            UpdateMarkerScaleLabel(markerScaleSlider.value);
+            UpdateMarkerColorLabels();
+            UpdateDebugMarkerControlInteractivity();
         }
 
         private void BuildHudPanel(Transform parent)
@@ -323,6 +397,138 @@ namespace WH30K.UI
             return button;
         }
 
+        private Toggle CreateToggle(string name, Transform parent, Vector2 anchoredPosition, string label)
+        {
+            var toggleGO = new GameObject(name, typeof(RectTransform));
+            toggleGO.transform.SetParent(parent, false);
+            var rect = toggleGO.GetComponent<RectTransform>();
+            rect.sizeDelta = new Vector2(24f, 24f);
+            rect.anchorMin = rect.anchorMax = new Vector2(0f, 1f);
+            rect.anchoredPosition = anchoredPosition;
+
+            var backgroundGO = new GameObject("Background", typeof(RectTransform), typeof(Image));
+            backgroundGO.transform.SetParent(toggleGO.transform, false);
+            var backgroundRect = backgroundGO.GetComponent<RectTransform>();
+            backgroundRect.anchorMin = Vector2.zero;
+            backgroundRect.anchorMax = Vector2.one;
+            backgroundRect.offsetMin = Vector2.zero;
+            backgroundRect.offsetMax = Vector2.zero;
+            var backgroundImage = backgroundGO.GetComponent<Image>();
+            backgroundImage.color = new Color(0.2f, 0.2f, 0.2f, 0.9f);
+
+            var checkmarkGO = new GameObject("Checkmark", typeof(RectTransform), typeof(Image));
+            checkmarkGO.transform.SetParent(backgroundGO.transform, false);
+            var checkmarkRect = checkmarkGO.GetComponent<RectTransform>();
+            checkmarkRect.anchorMin = new Vector2(0.25f, 0.25f);
+            checkmarkRect.anchorMax = new Vector2(0.75f, 0.75f);
+            checkmarkRect.offsetMin = Vector2.zero;
+            checkmarkRect.offsetMax = Vector2.zero;
+            var checkmarkImage = checkmarkGO.GetComponent<Image>();
+            checkmarkImage.color = new Color(0.35f, 0.8f, 0.35f, 0.95f);
+            checkmarkImage.raycastTarget = false;
+
+            var toggle = toggleGO.AddComponent<Toggle>();
+            toggle.targetGraphic = backgroundImage;
+            toggle.graphic = checkmarkImage;
+
+            var colors = toggle.colors;
+            colors.normalColor = backgroundImage.color;
+            colors.highlightedColor = new Color(0.3f, 0.3f, 0.3f, 0.95f);
+            colors.pressedColor = new Color(0.15f, 0.15f, 0.15f, 1f);
+            toggle.colors = colors;
+
+            CreateLabel($"{name}Label", parent, label, 14, TextAnchor.MiddleLeft,
+                new Vector2(anchoredPosition.x + 30f, anchoredPosition.y), PanelWidth - 70f, 24f);
+
+            return toggle;
+        }
+
+        private Slider CreateSlider(string name, Transform parent, Vector2 anchoredPosition, float width)
+        {
+            var sliderGO = new GameObject(name, typeof(RectTransform));
+            sliderGO.transform.SetParent(parent, false);
+            var rect = sliderGO.GetComponent<RectTransform>();
+            rect.sizeDelta = new Vector2(width, 24f);
+            rect.anchorMin = rect.anchorMax = new Vector2(0f, 1f);
+            rect.anchoredPosition = anchoredPosition;
+
+            var backgroundGO = new GameObject("Background", typeof(RectTransform), typeof(Image));
+            backgroundGO.transform.SetParent(sliderGO.transform, false);
+            var backgroundRect = backgroundGO.GetComponent<RectTransform>();
+            backgroundRect.anchorMin = Vector2.zero;
+            backgroundRect.anchorMax = Vector2.one;
+            backgroundRect.offsetMin = Vector2.zero;
+            backgroundRect.offsetMax = Vector2.zero;
+            var backgroundImage = backgroundGO.GetComponent<Image>();
+            backgroundImage.color = new Color(0.15f, 0.15f, 0.15f, 0.95f);
+
+            var fillAreaGO = new GameObject("Fill Area", typeof(RectTransform));
+            fillAreaGO.transform.SetParent(sliderGO.transform, false);
+            var fillAreaRect = fillAreaGO.GetComponent<RectTransform>();
+            fillAreaRect.anchorMin = new Vector2(0f, 0.25f);
+            fillAreaRect.anchorMax = new Vector2(1f, 0.75f);
+            fillAreaRect.offsetMin = new Vector2(6f, 0f);
+            fillAreaRect.offsetMax = new Vector2(-16f, 0f);
+
+            var fillGO = new GameObject("Fill", typeof(RectTransform), typeof(Image));
+            fillGO.transform.SetParent(fillAreaGO.transform, false);
+            var fillRect = fillGO.GetComponent<RectTransform>();
+            fillRect.anchorMin = new Vector2(0f, 0f);
+            fillRect.anchorMax = new Vector2(1f, 1f);
+            fillRect.offsetMin = Vector2.zero;
+            fillRect.offsetMax = Vector2.zero;
+            var fillImage = fillGO.GetComponent<Image>();
+            fillImage.color = new Color(0.35f, 0.55f, 0.95f, 0.9f);
+            fillImage.raycastTarget = false;
+
+            var handleAreaGO = new GameObject("Handle Slide Area", typeof(RectTransform));
+            handleAreaGO.transform.SetParent(sliderGO.transform, false);
+            var handleAreaRect = handleAreaGO.GetComponent<RectTransform>();
+            handleAreaRect.anchorMin = new Vector2(0f, 0f);
+            handleAreaRect.anchorMax = new Vector2(1f, 1f);
+            handleAreaRect.offsetMin = new Vector2(6f, 0f);
+            handleAreaRect.offsetMax = new Vector2(-6f, 0f);
+
+            var handleGO = new GameObject("Handle", typeof(RectTransform), typeof(Image));
+            handleGO.transform.SetParent(handleAreaGO.transform, false);
+            var handleRect = handleGO.GetComponent<RectTransform>();
+            handleRect.sizeDelta = new Vector2(16f, 28f);
+            handleRect.anchorMin = new Vector2(0f, 0.5f);
+            handleRect.anchorMax = new Vector2(0f, 0.5f);
+            handleRect.anchoredPosition = Vector2.zero;
+            var handleImage = handleGO.GetComponent<Image>();
+            handleImage.color = Color.white;
+
+            var slider = sliderGO.AddComponent<Slider>();
+            slider.fillRect = fillRect;
+            slider.handleRect = handleRect;
+            slider.targetGraphic = handleImage;
+            slider.direction = Slider.Direction.LeftToRight;
+            slider.transition = Selectable.Transition.ColorTint;
+
+            var colors = slider.colors;
+            colors.normalColor = handleImage.color;
+            colors.highlightedColor = new Color(0.8f, 0.8f, 0.8f, 1f);
+            colors.pressedColor = new Color(0.6f, 0.6f, 0.6f, 1f);
+            slider.colors = colors;
+
+            return slider;
+        }
+
+        private Slider CreateColorSlider(string name, Transform parent, Vector2 anchoredPosition, out Text valueLabel,
+            string channelLabel)
+        {
+            CreateLabel($"{name}Label", parent, channelLabel, 14, TextAnchor.MiddleLeft,
+                new Vector2(anchoredPosition.x - 30f, anchoredPosition.y), 24f, 20f);
+            valueLabel = CreateLabel($"{name}Value", parent, "0", 14, TextAnchor.MiddleRight,
+                new Vector2(PanelWidth - 70f, anchoredPosition.y), 60f, 20f);
+            var slider = CreateSlider(name, parent, anchoredPosition, PanelWidth - 110f);
+            slider.minValue = 0f;
+            slider.maxValue = 1f;
+            slider.wholeNumbers = false;
+            return slider;
+        }
+
         private void CycleDifficulty()
         {
             var order = GameSettings.GetAllDefinitions();
@@ -368,6 +574,133 @@ namespace WH30K.UI
             bootstrap.LoadFromFile();
         }
 
+        private void OnSpawnMarkersToggleChanged(bool isOn)
+        {
+            UpdateDebugMarkerControlInteractivity();
+            if (suppressDebugControlCallbacks)
+            {
+                return;
+            }
+
+            bootstrap?.SetSpawnDebugMarkers(isOn);
+        }
+
+        private void OnMarkerCountSliderChanged(float value)
+        {
+            UpdateMarkerCountLabel(value);
+            if (suppressDebugControlCallbacks)
+            {
+                return;
+            }
+
+            bootstrap?.SetDebugMarkerCount(Mathf.RoundToInt(value));
+        }
+
+        private void OnMarkerScaleSliderChanged(float value)
+        {
+            UpdateMarkerScaleLabel(value);
+            if (suppressDebugControlCallbacks)
+            {
+                return;
+            }
+
+            bootstrap?.SetDebugMarkerScale(value);
+        }
+
+        private void OnMarkerColorSliderChanged(float value)
+        {
+            UpdateMarkerColorLabels();
+            if (suppressDebugControlCallbacks)
+            {
+                return;
+            }
+
+            var color = new Color(
+                markerRedSlider != null ? markerRedSlider.value : 0f,
+                markerGreenSlider != null ? markerGreenSlider.value : 0f,
+                markerBlueSlider != null ? markerBlueSlider.value : 0f);
+            bootstrap?.SetDebugMarkerColor(color);
+        }
+
+        private void OnRegenerateMarkersClicked()
+        {
+            if (suppressDebugControlCallbacks)
+            {
+                return;
+            }
+
+            bootstrap?.RegenerateDebugMarkers();
+        }
+
+        private void UpdateMarkerCountLabel(float value)
+        {
+            if (markerCountValueLabel != null)
+            {
+                markerCountValueLabel.text = Mathf.RoundToInt(value).ToString();
+            }
+        }
+
+        private void UpdateMarkerScaleLabel(float value)
+        {
+            if (markerScaleValueLabel != null)
+            {
+                markerScaleValueLabel.text = value.ToString("0.0");
+            }
+        }
+
+        private void UpdateMarkerColorLabels()
+        {
+            if (markerRedValueLabel != null && markerRedSlider != null)
+            {
+                markerRedValueLabel.text = Mathf.RoundToInt(markerRedSlider.value * 255f).ToString();
+            }
+
+            if (markerGreenValueLabel != null && markerGreenSlider != null)
+            {
+                markerGreenValueLabel.text = Mathf.RoundToInt(markerGreenSlider.value * 255f).ToString();
+            }
+
+            if (markerBlueValueLabel != null && markerBlueSlider != null)
+            {
+                markerBlueValueLabel.text = Mathf.RoundToInt(markerBlueSlider.value * 255f).ToString();
+            }
+        }
+
+        private void UpdateDebugMarkerControlInteractivity()
+        {
+            var interactive = spawnMarkersToggle != null && spawnMarkersToggle.isOn;
+
+            if (markerCountSlider != null)
+            {
+                markerCountSlider.interactable = interactive;
+            }
+
+            if (markerScaleSlider != null)
+            {
+                markerScaleSlider.interactable = interactive;
+            }
+
+            if (markerRedSlider != null)
+            {
+                markerRedSlider.interactable = interactive;
+            }
+
+            if (markerGreenSlider != null)
+            {
+                markerGreenSlider.interactable = interactive;
+            }
+
+            if (markerBlueSlider != null)
+            {
+                markerBlueSlider.interactable = interactive;
+            }
+
+            if (regenerateMarkersButton != null)
+            {
+                regenerateMarkersButton.interactable = interactive;
+            }
+        }
+
         public void ShowNewGamePanel(bool visible)
         {
             newGamePanel.SetActive(visible);
@@ -383,6 +716,50 @@ namespace WH30K.UI
         public void ShowEventPanel(bool visible)
         {
             eventPanel.SetActive(visible);
+        }
+
+        public void InitializeDebugMarkerControls(bool spawn, int count, float scale, Color color)
+        {
+            if (spawnMarkersToggle == null)
+            {
+                return;
+            }
+
+            suppressDebugControlCallbacks = true;
+
+            spawnMarkersToggle.isOn = spawn;
+
+            if (markerCountSlider != null)
+            {
+                markerCountSlider.value = Mathf.Clamp(count, markerCountSlider.minValue, markerCountSlider.maxValue);
+                UpdateMarkerCountLabel(markerCountSlider.value);
+            }
+
+            if (markerScaleSlider != null)
+            {
+                markerScaleSlider.value = Mathf.Clamp(scale, markerScaleSlider.minValue, markerScaleSlider.maxValue);
+                UpdateMarkerScaleLabel(markerScaleSlider.value);
+            }
+
+            if (markerRedSlider != null)
+            {
+                markerRedSlider.value = Mathf.Clamp01(color.r);
+            }
+
+            if (markerGreenSlider != null)
+            {
+                markerGreenSlider.value = Mathf.Clamp01(color.g);
+            }
+
+            if (markerBlueSlider != null)
+            {
+                markerBlueSlider.value = Mathf.Clamp01(color.b);
+            }
+
+            UpdateMarkerColorLabels();
+
+            suppressDebugControlCallbacks = false;
+            UpdateDebugMarkerControlInteractivity();
         }
 
 


### PR DESCRIPTION
## Summary
- expose the debug marker options in a dedicated runtime panel with sliders, toggles, and a respawn button
- drive marker spawning, scaling, and coloring from the new UI while cleaning up editor-only guards in `PlanetBootstrap`
- refresh marker state when loading saves and ensure editor materials are disposed safely

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68d2b76662ec8322b58640e45837f54b