### PR TITLE
Add in-game debug tools panel

### DIFF
--- a/Assets/Scripts/Planet/PlanetBootstrap.cs
+++ b/Assets/Scripts/Planet/PlanetBootstrap.cs
@@ -265,6 +265,17 @@ namespace WH30K.Gameplay
         }
 
 #if UNITY_EDITOR
+        private void DestroyDebugMarkerRoot()
+        {
+            if (debugMarkerRoot == null)
+            {
+                return;
+            }
+
+            Destroy(debugMarkerRoot.gameObject);
+            debugMarkerRoot = null;
+        }
+
         private void SpawnDebugMarkers()
         {
             if (planet == null)
@@ -272,11 +283,7 @@ namespace WH30K.Gameplay
                 return;
             }
 
-            if (debugMarkerRoot != null)
-            {
-                Destroy(debugMarkerRoot.gameObject);
-                debugMarkerRoot = null;
-            }
+            DestroyDebugMarkerRoot();
 
             if (!hasLastSurfacePoint && debugMarkerCount <= 0)
             {
@@ -354,6 +361,101 @@ namespace WH30K.Gameplay
                 renderer.sharedMaterial = debugMarkerMaterial;
             }
         }
+
+        public bool DebugMarkersEnabled
+        {
+            get => spawnDebugMarkers;
+            set
+            {
+                if (spawnDebugMarkers == value)
+                {
+                    return;
+                }
+
+                spawnDebugMarkers = value;
+                if (!spawnDebugMarkers)
+                {
+                    DestroyDebugMarkerRoot();
+                }
+                else if (planet != null)
+                {
+                    SpawnDebugMarkers();
+                }
+            }
+        }
+
+        public int DebugMarkerCount
+        {
+            get => debugMarkerCount;
+            set
+            {
+                var clamped = Mathf.Max(0, value);
+                if (debugMarkerCount == clamped)
+                {
+                    return;
+                }
+
+                debugMarkerCount = clamped;
+                if (spawnDebugMarkers && planet != null)
+                {
+                    SpawnDebugMarkers();
+                }
+            }
+        }
+
+        public float DebugMarkerScale
+        {
+            get => debugMarkerScale;
+            set
+            {
+                var clamped = Mathf.Max(0.01f, value);
+                if (Mathf.Approximately(debugMarkerScale, clamped))
+                {
+                    return;
+                }
+
+                debugMarkerScale = clamped;
+                if (debugMarkerRoot == null)
+                {
+                    return;
+                }
+
+                foreach (Transform child in debugMarkerRoot)
+                {
+                    child.localScale = Vector3.one * debugMarkerScale;
+                }
+            }
+        }
+
+        public Color DebugMarkerColor
+        {
+            get => debugMarkerColor;
+            set
+            {
+                debugMarkerColor = value;
+                if (debugMarkerMaterial != null)
+                {
+                    debugMarkerMaterial.color = debugMarkerColor;
+                }
+            }
+        }
+
+        public void DebugRespawnMarkers()
+        {
+            if (planet == null)
+            {
+                return;
+            }
+
+            SpawnDebugMarkers();
+        }
+
+        public void DebugClearMarkers()
+        {
+            DestroyDebugMarkerRoot();
+        }
+
+        public bool HasDebugMarkers => debugMarkerRoot != null && debugMarkerRoot.childCount > 0;
 #endif
 
 

--- a/Assets/Scripts/Sim/Events/EventSystem.cs
+++ b/Assets/Scripts/Sim/Events/EventSystem.cs
@@ -23,6 +23,8 @@ namespace WH30K.Sim.Events
         private Coroutine eventCoroutine;
         private System.Random rng;
 
+        public bool HasActiveSession => rng != null;
+
         public void ConfigureMenu(NewGameMenu newMenu)
         {
             menu = newMenu;
@@ -102,5 +104,23 @@ namespace WH30K.Sim.Events
             });
             menu?.AppendEventLog("Ordered furnaces into overdrive to meet production quotas.");
         }
+
+#if UNITY_EDITOR
+        public void TriggerDebugEventNow()
+        {
+            if (!HasActiveSession)
+            {
+                return;
+            }
+
+            if (eventCoroutine != null)
+            {
+                StopCoroutine(eventCoroutine);
+                eventCoroutine = null;
+            }
+
+            TriggerIndustrialPolicyEvent();
+        }
+#endif
     }
 }

--- a/Assets/Scripts/Sim/Settlement.cs
+++ b/Assets/Scripts/Sim/Settlement.cs
@@ -66,6 +66,8 @@ namespace WH30K.Sim.Settlements
             menu = newMenu;
         }
 
+        public bool HasActiveSimulation => planet != null && resourceSystem != null && environmentState != null;
+
         public void BeginNewGame(GameSettings.DifficultyDefinition definition, LODPlanet planetInstance,
             Vector3 surfacePosition, Vector3 surfaceNormal, ResourceSystem resources, EnvironmentState environment)
         {
@@ -155,6 +157,18 @@ namespace WH30K.Sim.Settlements
                 menu?.AppendEventLog(message);
             }
         }
+
+#if UNITY_EDITOR
+        public void DebugRunImmediateTick()
+        {
+            if (!HasActiveSimulation)
+            {
+                return;
+            }
+
+            RunTick();
+        }
+#endif
 
         private void RunTick()
         {


### PR DESCRIPTION
## Summary
- add an editor-only debug tools panel to the runtime UI for toggling debug markers, advancing ticks, granting stockpile, and firing events
- expose marker control helpers on the planet bootstrap plus settlement and event debug hooks to support the panel
- keep the tools editor-only and gated by active game checks while logging actions to the HUD log

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68d3b8093d80832285757cf4cb3e2ac2