### PR TITLE
Add in-game debug tools panel

### DIFF
--- a/Assets/Scripts/Game/NewGameMenu.cs
+++ b/Assets/Scripts/Game/NewGameMenu.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+#if UNITY_EDITOR
+using System.Globalization;
+#endif
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
@@ -24,6 +27,9 @@ namespace WH30K.UI
         private const float PanelWidth = 320f;
         private const float PanelHeight = 210f;
         private const float HudPanelWidth = 260f;
+#if UNITY_EDITOR
+        private const float DebugPanelWidth = 260f;
+#endif
 
         private PlanetBootstrap bootstrap;
         private ResourceSystem resourceSystem;
@@ -58,6 +64,19 @@ namespace WH30K.UI
         private Action eventChoiceBHandler;
 
         private Font defaultFont;
+
+#if UNITY_EDITOR
+        private GameObject debugPanel;
+        private Button debugMarkersToggleButton;
+        private Text debugMarkersToggleLabel;
+        private InputField debugMarkerCountInput;
+        private InputField debugMarkerScaleInput;
+        private Button debugMarkersRespawnButton;
+        private Button debugMarkersClearButton;
+        private Button debugAdvanceTickButton;
+        private Button debugAddStockpileButton;
+        private Button debugTriggerEventButton;
+#endif
 
         private void Awake()
         {
@@ -108,6 +127,9 @@ namespace WH30K.UI
             BuildNewGamePanel(canvas.transform);
             BuildHudPanel(canvas.transform);
             BuildEventPanel(canvas.transform);
+#if UNITY_EDITOR
+            BuildDebugPanel(canvas.transform);
+#endif
         }
 
         private void ConfigureDefaultValues()
@@ -119,6 +141,9 @@ namespace WH30K.UI
             ShowNewGamePanel(true);
             ShowHud(false);
             ShowEventPanel(false);
+#if UNITY_EDITOR
+            UpdateDebugPanelState();
+#endif
         }
 
         private void BuildNewGamePanel(Transform parent)
@@ -196,18 +221,22 @@ namespace WH30K.UI
                 case TextAnchor.UpperLeft:
                     rect.anchorMin = new Vector2(0f, 1f);
                     rect.anchorMax = new Vector2(0f, 1f);
+                    rect.pivot = new Vector2(0f, 1f);
                     break;
                 case TextAnchor.UpperRight:
                     rect.anchorMin = new Vector2(1f, 1f);
                     rect.anchorMax = new Vector2(1f, 1f);
+                    rect.pivot = new Vector2(1f, 1f);
                     break;
                 case TextAnchor.MiddleCenter:
                     rect.anchorMin = new Vector2(0.5f, 0.5f);
                     rect.anchorMax = new Vector2(0.5f, 0.5f);
+                    rect.pivot = new Vector2(0.5f, 0.5f);
                     break;
                 default:
                     rect.anchorMin = new Vector2(0.5f, 0.5f);
                     rect.anchorMax = new Vector2(0.5f, 0.5f);
+                    rect.pivot = new Vector2(0.5f, 0.5f);
                     break;
             }
 
@@ -224,6 +253,7 @@ namespace WH30K.UI
             var rect = labelGO.GetComponent<RectTransform>();
             rect.sizeDelta = new Vector2(width, height);
             rect.anchorMin = rect.anchorMax = new Vector2(0f, 1f);
+            rect.pivot = new Vector2(0f, 1f);
             rect.anchoredPosition = anchoredPosition;
 
             var text = labelGO.AddComponent<Text>();
@@ -237,13 +267,15 @@ namespace WH30K.UI
             return text;
         }
 
-        private InputField CreateInputField(string name, Transform parent, Vector2 anchoredPosition)
+        private InputField CreateInputField(string name, Transform parent, Vector2 anchoredPosition, float width = PanelWidth - 40f,
+            InputField.ContentType contentType = InputField.ContentType.IntegerNumber, string placeholderText = "Random")
         {
             var inputGO = new GameObject(name, typeof(RectTransform), typeof(Image));
             inputGO.transform.SetParent(parent, false);
             var rect = inputGO.GetComponent<RectTransform>();
-            rect.sizeDelta = new Vector2(PanelWidth - 40f, 32f);
+            rect.sizeDelta = new Vector2(width, 32f);
             rect.anchorMin = rect.anchorMax = new Vector2(0f, 1f);
+            rect.pivot = new Vector2(0f, 1f);
             rect.anchoredPosition = anchoredPosition;
 
             var image = inputGO.GetComponent<Image>();
@@ -276,12 +308,12 @@ namespace WH30K.UI
             placeholder.fontSize = 14;
             placeholder.color = new Color(1f, 1f, 1f, 0.35f);
             placeholder.alignment = TextAnchor.MiddleLeft;
-            placeholder.text = "Random";
+            placeholder.text = placeholderText;
 
             var inputField = inputGO.AddComponent<InputField>();
             inputField.textComponent = text;
             inputField.placeholder = placeholder;
-            inputField.contentType = InputField.ContentType.IntegerNumber;
+            inputField.contentType = contentType;
             return inputField;
         }
 
@@ -293,6 +325,7 @@ namespace WH30K.UI
             var rect = buttonGO.GetComponent<RectTransform>();
             rect.sizeDelta = new Vector2(width, 36f);
             rect.anchorMin = rect.anchorMax = new Vector2(0f, 1f);
+            rect.pivot = new Vector2(0f, 1f);
             rect.anchoredPosition = anchoredPosition;
 
             var image = buttonGO.GetComponent<Image>();
@@ -378,6 +411,9 @@ namespace WH30K.UI
         public void ShowHud(bool visible)
         {
             hudPanel.SetActive(visible);
+#if UNITY_EDITOR
+            UpdateDebugPanelState();
+#endif
         }
 
         public void ShowEventPanel(bool visible)
@@ -460,5 +496,234 @@ namespace WH30K.UI
 
             ShowEventPanel(true);
         }
+
+#if UNITY_EDITOR
+        private void BuildDebugPanel(Transform parent)
+        {
+            debugPanel = CreatePanel("DebugPanel", parent, new Vector2(DebugPanelWidth, 320f),
+                new Vector2(10f, -PanelHeight - 30f), TextAnchor.UpperLeft);
+
+            CreateLabel("DebugTitle", debugPanel.transform, "Debug Tools", 18, TextAnchor.UpperLeft,
+                new Vector2(0f, -12f), DebugPanelWidth - 20f);
+
+            debugMarkersToggleButton = CreateButton("ToggleMarkers", debugPanel.transform, new Vector2(0f, -46f),
+                "Debug Markers", out debugMarkersToggleLabel, DebugPanelWidth - 40f);
+            debugMarkersToggleButton.onClick.AddListener(ToggleDebugMarkers);
+
+            debugMarkerCountInput = CreateInputField("MarkerCount", debugPanel.transform, new Vector2(0f, -86f),
+                DebugPanelWidth - 40f, InputField.ContentType.IntegerNumber, "Marker Count");
+            debugMarkerCountInput.onEndEdit.AddListener(OnDebugMarkerCountChanged);
+
+            debugMarkerScaleInput = CreateInputField("MarkerScale", debugPanel.transform, new Vector2(0f, -126f),
+                DebugPanelWidth - 40f, InputField.ContentType.DecimalNumber, "Marker Scale");
+            debugMarkerScaleInput.onEndEdit.AddListener(OnDebugMarkerScaleChanged);
+
+            debugMarkersRespawnButton = CreateButton("RespawnMarkers", debugPanel.transform, new Vector2(0f, -166f),
+                "Respawn Markers", out _, (DebugPanelWidth - 50f) * 0.5f);
+            debugMarkersRespawnButton.onClick.AddListener(OnDebugMarkersRespawnClicked);
+
+            debugMarkersClearButton = CreateButton("ClearMarkers", debugPanel.transform,
+                new Vector2((DebugPanelWidth * 0.5f) + 5f, -166f), "Clear Markers", out _, (DebugPanelWidth - 50f) * 0.5f);
+            debugMarkersClearButton.onClick.AddListener(OnDebugMarkersClearClicked);
+
+            debugAdvanceTickButton = CreateButton("AdvanceTick", debugPanel.transform, new Vector2(0f, -206f),
+                "Advance Settlement Tick", out _, DebugPanelWidth - 40f);
+            debugAdvanceTickButton.onClick.AddListener(OnDebugAdvanceTickClicked);
+
+            debugAddStockpileButton = CreateButton("AddStockpile", debugPanel.transform, new Vector2(0f, -246f),
+                "Inject +100 Stockpile", out _, DebugPanelWidth - 40f);
+            debugAddStockpileButton.onClick.AddListener(OnDebugAddStockpileClicked);
+
+            debugTriggerEventButton = CreateButton("TriggerEvent", debugPanel.transform, new Vector2(0f, -286f),
+                "Trigger Event", out _, DebugPanelWidth - 40f);
+            debugTriggerEventButton.onClick.AddListener(OnDebugTriggerEventClicked);
+
+            UpdateDebugPanelState();
+        }
+
+        private void UpdateDebugPanelState()
+        {
+            if (debugPanel == null)
+            {
+                return;
+            }
+
+            var hasActiveGame = GameSettings.HasActiveGame;
+            var markersEnabled = hasActiveGame && bootstrap != null && bootstrap.DebugMarkersEnabled;
+
+            if (debugMarkersToggleLabel != null)
+            {
+                var label = markersEnabled ? "Debug Markers: On" : "Debug Markers: Off";
+                if (debugMarkersToggleLabel.text != label)
+                {
+                    debugMarkersToggleLabel.text = label;
+                }
+            }
+
+            if (bootstrap != null)
+            {
+                var countText = bootstrap.DebugMarkerCount.ToString(CultureInfo.InvariantCulture);
+                if (debugMarkerCountInput != null && debugMarkerCountInput.text != countText)
+                {
+                    debugMarkerCountInput.text = countText;
+                }
+
+                var scaleText = bootstrap.DebugMarkerScale.ToString("0.##", CultureInfo.InvariantCulture);
+                if (debugMarkerScaleInput != null && debugMarkerScaleInput.text != scaleText)
+                {
+                    debugMarkerScaleInput.text = scaleText;
+                }
+            }
+
+            if (debugMarkersToggleButton != null)
+            {
+                debugMarkersToggleButton.interactable = hasActiveGame && bootstrap != null;
+            }
+
+            if (debugMarkerCountInput != null)
+            {
+                debugMarkerCountInput.interactable = hasActiveGame && bootstrap != null;
+            }
+
+            if (debugMarkerScaleInput != null)
+            {
+                debugMarkerScaleInput.interactable = hasActiveGame && bootstrap != null;
+            }
+
+            if (debugMarkersRespawnButton != null)
+            {
+                debugMarkersRespawnButton.interactable = hasActiveGame && bootstrap != null && bootstrap.DebugMarkersEnabled;
+            }
+
+            if (debugMarkersClearButton != null)
+            {
+                var hasMarkers = hasActiveGame && bootstrap != null && bootstrap.HasDebugMarkers;
+                debugMarkersClearButton.interactable = hasMarkers;
+            }
+
+            if (debugAdvanceTickButton != null)
+            {
+                debugAdvanceTickButton.interactable = hasActiveGame && settlement != null && settlement.HasActiveSimulation;
+            }
+
+            if (debugAddStockpileButton != null)
+            {
+                debugAddStockpileButton.interactable = hasActiveGame && resourceSystem != null;
+            }
+
+            if (debugTriggerEventButton != null)
+            {
+                debugTriggerEventButton.interactable = hasActiveGame && colonyEventSystem != null && colonyEventSystem.HasActiveSession;
+            }
+        }
+
+        private void ToggleDebugMarkers()
+        {
+            if (!GameSettings.HasActiveGame || bootstrap == null)
+            {
+                UpdateDebugPanelState();
+                return;
+            }
+
+            bootstrap.DebugMarkersEnabled = !bootstrap.DebugMarkersEnabled;
+            UpdateDebugPanelState();
+        }
+
+        private void OnDebugMarkerCountChanged(string value)
+        {
+            if (!GameSettings.HasActiveGame || bootstrap == null)
+            {
+                UpdateDebugPanelState();
+                return;
+            }
+
+            if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var count))
+            {
+                bootstrap.DebugMarkerCount = count;
+            }
+
+            UpdateDebugPanelState();
+        }
+
+        private void OnDebugMarkerScaleChanged(string value)
+        {
+            if (!GameSettings.HasActiveGame || bootstrap == null)
+            {
+                UpdateDebugPanelState();
+                return;
+            }
+
+            if (float.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var scale))
+            {
+                bootstrap.DebugMarkerScale = scale;
+            }
+
+            UpdateDebugPanelState();
+        }
+
+        private void OnDebugMarkersRespawnClicked()
+        {
+            if (!GameSettings.HasActiveGame || bootstrap == null)
+            {
+                UpdateDebugPanelState();
+                return;
+            }
+
+            bootstrap.DebugMarkersEnabled = true;
+            bootstrap.DebugRespawnMarkers();
+            UpdateDebugPanelState();
+        }
+
+        private void OnDebugMarkersClearClicked()
+        {
+            if (!GameSettings.HasActiveGame || bootstrap == null)
+            {
+                UpdateDebugPanelState();
+                return;
+            }
+
+            bootstrap.DebugClearMarkers();
+            UpdateDebugPanelState();
+        }
+
+        private void OnDebugAdvanceTickClicked()
+        {
+            if (!GameSettings.HasActiveGame || settlement == null || !settlement.HasActiveSimulation)
+            {
+                UpdateDebugPanelState();
+                return;
+            }
+
+            settlement.DebugRunImmediateTick();
+            AppendEventLog("[DEBUG] Advanced settlement tick.");
+            UpdateDebugPanelState();
+        }
+
+        private void OnDebugAddStockpileClicked()
+        {
+            if (!GameSettings.HasActiveGame || resourceSystem == null)
+            {
+                UpdateDebugPanelState();
+                return;
+            }
+
+            resourceSystem.ModifyStockpile(100f);
+            AppendEventLog("[DEBUG] Injected +100 stockpile.");
+            UpdateDebugPanelState();
+        }
+
+        private void OnDebugTriggerEventClicked()
+        {
+            if (!GameSettings.HasActiveGame || colonyEventSystem == null || !colonyEventSystem.HasActiveSession)
+            {
+                UpdateDebugPanelState();
+                return;
+            }
+
+            colonyEventSystem.TriggerDebugEventNow();
+            AppendEventLog("[DEBUG] Manually triggered event.");
+            UpdateDebugPanelState();
+        }
+#endif
     }
 }

--- a/Assets/Scripts/Planet/PlanetBootstrap.cs
+++ b/Assets/Scripts/Planet/PlanetBootstrap.cs
@@ -265,6 +265,17 @@ namespace WH30K.Gameplay
         }
 
 #if UNITY_EDITOR
+        private void DestroyDebugMarkerRoot()
+        {
+            if (debugMarkerRoot == null)
+            {
+                return;
+            }
+
+            Destroy(debugMarkerRoot.gameObject);
+            debugMarkerRoot = null;
+        }
+
         private void SpawnDebugMarkers()
         {
             if (planet == null)
@@ -272,11 +283,7 @@ namespace WH30K.Gameplay
                 return;
             }
 
-            if (debugMarkerRoot != null)
-            {
-                Destroy(debugMarkerRoot.gameObject);
-                debugMarkerRoot = null;
-            }
+            DestroyDebugMarkerRoot();
 
             if (!hasLastSurfacePoint && debugMarkerCount <= 0)
             {
@@ -354,6 +361,101 @@ namespace WH30K.Gameplay
                 renderer.sharedMaterial = debugMarkerMaterial;
             }
         }
+
+        public bool DebugMarkersEnabled
+        {
+            get => spawnDebugMarkers;
+            set
+            {
+                if (spawnDebugMarkers == value)
+                {
+                    return;
+                }
+
+                spawnDebugMarkers = value;
+                if (!spawnDebugMarkers)
+                {
+                    DestroyDebugMarkerRoot();
+                }
+                else if (planet != null)
+                {
+                    SpawnDebugMarkers();
+                }
+            }
+        }
+
+        public int DebugMarkerCount
+        {
+            get => debugMarkerCount;
+            set
+            {
+                var clamped = Mathf.Max(0, value);
+                if (debugMarkerCount == clamped)
+                {
+                    return;
+                }
+
+                debugMarkerCount = clamped;
+                if (spawnDebugMarkers && planet != null)
+                {
+                    SpawnDebugMarkers();
+                }
+            }
+        }
+
+        public float DebugMarkerScale
+        {
+            get => debugMarkerScale;
+            set
+            {
+                var clamped = Mathf.Max(0.01f, value);
+                if (Mathf.Approximately(debugMarkerScale, clamped))
+                {
+                    return;
+                }
+
+                debugMarkerScale = clamped;
+                if (debugMarkerRoot == null)
+                {
+                    return;
+                }
+
+                foreach (Transform child in debugMarkerRoot)
+                {
+                    child.localScale = Vector3.one * debugMarkerScale;
+                }
+            }
+        }
+
+        public Color DebugMarkerColor
+        {
+            get => debugMarkerColor;
+            set
+            {
+                debugMarkerColor = value;
+                if (debugMarkerMaterial != null)
+                {
+                    debugMarkerMaterial.color = debugMarkerColor;
+                }
+            }
+        }
+
+        public void DebugRespawnMarkers()
+        {
+            if (planet == null)
+            {
+                return;
+            }
+
+            SpawnDebugMarkers();
+        }
+
+        public void DebugClearMarkers()
+        {
+            DestroyDebugMarkerRoot();
+        }
+
+        public bool HasDebugMarkers => debugMarkerRoot != null && debugMarkerRoot.childCount > 0;
 #endif
 
 

--- a/Assets/Scripts/Sim/Events/EventSystem.cs
+++ b/Assets/Scripts/Sim/Events/EventSystem.cs
@@ -23,6 +23,8 @@ namespace WH30K.Sim.Events
         private Coroutine eventCoroutine;
         private System.Random rng;
 
+        public bool HasActiveSession => rng != null;
+
         public void ConfigureMenu(NewGameMenu newMenu)
         {
             menu = newMenu;
@@ -102,5 +104,23 @@ namespace WH30K.Sim.Events
             });
             menu?.AppendEventLog("Ordered furnaces into overdrive to meet production quotas.");
         }
+
+#if UNITY_EDITOR
+        public void TriggerDebugEventNow()
+        {
+            if (!HasActiveSession)
+            {
+                return;
+            }
+
+            if (eventCoroutine != null)
+            {
+                StopCoroutine(eventCoroutine);
+                eventCoroutine = null;
+            }
+
+            TriggerIndustrialPolicyEvent();
+        }
+#endif
     }
 }

--- a/Assets/Scripts/Sim/Settlement.cs
+++ b/Assets/Scripts/Sim/Settlement.cs
@@ -66,6 +66,8 @@ namespace WH30K.Sim.Settlements
             menu = newMenu;
         }
 
+        public bool HasActiveSimulation => planet != null && resourceSystem != null && environmentState != null;
+
         public void BeginNewGame(GameSettings.DifficultyDefinition definition, LODPlanet planetInstance,
             Vector3 surfacePosition, Vector3 surfaceNormal, ResourceSystem resources, EnvironmentState environment)
         {
@@ -155,6 +157,18 @@ namespace WH30K.Sim.Settlements
                 menu?.AppendEventLog(message);
             }
         }
+
+#if UNITY_EDITOR
+        public void DebugRunImmediateTick()
+        {
+            if (!HasActiveSimulation)
+            {
+                return;
+            }
+
+            RunTick();
+        }
+#endif
 
         private void RunTick()
         {


### PR DESCRIPTION
## Summary
- add an editor-only debug tools panel to the runtime UI for toggling debug markers, advancing ticks, granting stockpile, and firing events
- expose marker control helpers on the planet bootstrap plus settlement and event debug hooks to support the panel
- align the runtime UI pivots with their anchors so the menus appear in the Game view

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68d3b8093d80832285757cf4cb3e2ac2