### PR TITLE
Add planet-wide building placement grid and UI controls

### DIFF
--- a/Assets/Resources.meta
+++ b/Assets/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c4e86f2b9a044d1fbf0fd5dd3b73f75d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Buildings.meta
+++ b/Assets/Resources/Buildings.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4b117eb7d64243e39c3db1dfb2d0d0b4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Buildings/FrontierOutpost.asset
+++ b/Assets/Resources/Buildings/FrontierOutpost.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c59ef5f4d9a44a3e9d0fc35283a6b2cb, type: 3}
+  m_Name: FrontierOutpost
+  m_EditorClassIdentifier: 
+  id: Outpost
+  displayName: Frontier Outpost
+  dimensions: {x: 200, y: 150, z: 200}
+  previewColor: {r: 0.45, g: 0.95, b: 0.45, a: 0.6}
+  structureColor: {r: 0.6, g: 0.6, b: 0.72, a: 1}

--- a/Assets/Resources/Buildings/FrontierOutpost.asset.meta
+++ b/Assets/Resources/Buildings/FrontierOutpost.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9d5b9b7a7e6445afa0ceca6301aef7df
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/Construction.meta
+++ b/Assets/Scripts/Game/Construction.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5f82f3677085406ea9c4f8cc7fc5bd6d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/Construction/BuildableStructure.cs
+++ b/Assets/Scripts/Game/Construction/BuildableStructure.cs
@@ -1,0 +1,56 @@
+using UnityEngine;
+
+namespace WH30K.Gameplay.Construction
+{
+    /// <summary>
+    /// Definition for a buildable structure that can be deployed onto the planetary grid.
+    /// ScriptableObject assets using this definition are discovered at runtime via Resources.
+    /// </summary>
+    [CreateAssetMenu(menuName = "WH30K/Construction/Buildable Structure", fileName = "BuildableStructure")]
+    public class BuildableStructure : ScriptableObject
+    {
+        [Header("Identity")]
+        [SerializeField] private string id = "Outpost";
+        [SerializeField] private string displayName = "Frontier Outpost";
+
+        [Header("Presentation")]
+        [SerializeField] private Vector3 dimensions = new Vector3(180f, 140f, 180f);
+        [SerializeField] private Color previewColor = new Color(0.45f, 0.95f, 0.45f, 0.6f);
+        [SerializeField] private Color structureColor = new Color(0.6f, 0.6f, 0.72f, 1f);
+
+        /// <summary>
+        /// Unique identifier for the structure. Falls back to the asset name when not provided.
+        /// </summary>
+        public string Id => string.IsNullOrWhiteSpace(id) ? name : id;
+
+        /// <summary>
+        /// Human readable name shown in UI elements.
+        /// </summary>
+        public string DisplayName => string.IsNullOrWhiteSpace(displayName) ? Id : displayName;
+
+        /// <summary>
+        /// Returns the structure's dimensions, clamped to a sensible minimum to avoid degenerate visuals.
+        /// The value represents width (x), height (y) and depth (z) in Unity units.
+        /// </summary>
+        public Vector3 Dimensions
+        {
+            get
+            {
+                return new Vector3(
+                    Mathf.Max(20f, dimensions.x),
+                    Mathf.Max(20f, dimensions.y),
+                    Mathf.Max(20f, dimensions.z));
+            }
+        }
+
+        /// <summary>
+        /// Semi-transparent colour used for the holographic preview while positioning the structure.
+        /// </summary>
+        public Color PreviewColor => previewColor;
+
+        /// <summary>
+        /// Colour applied to the placed structure's material.
+        /// </summary>
+        public Color StructureColor => structureColor;
+    }
+}

--- a/Assets/Scripts/Game/Construction/BuildableStructure.cs.meta
+++ b/Assets/Scripts/Game/Construction/BuildableStructure.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c59ef5f4d9a44a3e9d0fc35283a6b2cb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/Construction/BuildingPlacementController.cs
+++ b/Assets/Scripts/Game/Construction/BuildingPlacementController.cs
@@ -1,0 +1,414 @@
+using System.Collections.Generic;
+using UnityEngine;
+using WH30K.Gameplay;
+using WH30K.Planet;
+using WH30K.UI;
+
+namespace WH30K.Gameplay.Construction
+{
+    /// <summary>
+    /// Handles user interaction for placing structures onto the procedural planet surface.
+    /// </summary>
+    [RequireComponent(typeof(PlanetBootstrap))]
+    public class BuildingPlacementController : MonoBehaviour
+    {
+        [Header("Grid")]
+        [SerializeField] private int cellsPerFace = 96;
+        [SerializeField] private float gridElevationOffset = 6f;
+
+        [Header("Preview Colours")]
+        [SerializeField] private Color validPreviewColor = new Color(0.5f, 1f, 0.5f, 0.6f);
+        [SerializeField] private Color invalidPreviewColor = new Color(1f, 0.35f, 0.35f, 0.6f);
+        [SerializeField] private Color allowedGridColor = new Color(0.6f, 1f, 0.6f, 0.35f);
+        [SerializeField] private Color blockedGridColor = new Color(1f, 0.4f, 0.4f, 0.35f);
+
+        private readonly Dictionary<PlanetGridCell, PlacedStructure> placedStructures = new Dictionary<PlanetGridCell, PlacedStructure>();
+        private static readonly Dictionary<Color, Material> MaterialCache = new Dictionary<Color, Material>();
+
+        private LODPlanet planet;
+        private PlanetGrid grid;
+        private PlanetGridVisualizer visualizer;
+        private BuildableStructure[] availableStructures;
+        private BuildableStructure activeStructure;
+        private GameObject previewInstance;
+        private MeshRenderer previewRenderer;
+        private Material previewMaterial;
+        private Material gridAllowedMaterial;
+        private Material gridBlockedMaterial;
+        private Transform structureRoot;
+        private NewGameMenu menu;
+        private Camera mainCamera;
+
+        private bool isPlacing;
+
+        public bool IsPlacing => isPlacing;
+        public string ActiveStructureName => activeStructure != null ? activeStructure.DisplayName : "Structure";
+
+        private void Awake()
+        {
+            availableStructures = Resources.LoadAll<BuildableStructure>("Buildings");
+            if (availableStructures == null || availableStructures.Length == 0)
+            {
+                Debug.LogWarning("No BuildableStructure assets found in Resources/Buildings. Using default runtime definition.");
+                var fallback = ScriptableObject.CreateInstance<BuildableStructure>();
+                fallback.hideFlags = HideFlags.HideAndDontSave;
+                availableStructures = new[] { fallback };
+            }
+
+            activeStructure = availableStructures[0];
+            mainCamera = Camera.main;
+        }
+
+        private void OnDisable()
+        {
+            CancelPlacement();
+        }
+
+        public void ConfigureMenu(NewGameMenu newMenu)
+        {
+            menu = newMenu;
+            menu?.UpdateBuildButtonState(ActiveStructureName, false);
+        }
+
+        public void AttachToPlanet(LODPlanet newPlanet)
+        {
+            planet = newPlanet;
+            grid = planet != null ? new PlanetGrid(planet, Mathf.Max(8, cellsPerFace)) : null;
+            RebuildVisualizer();
+            RebuildStructureRoot();
+            ClearPreviewInstance();
+            placedStructures.Clear();
+            isPlacing = false;
+            menu?.UpdateBuildButtonState(ActiveStructureName, false);
+        }
+
+        public void ResetPlacement()
+        {
+            foreach (var structure in placedStructures.Values)
+            {
+                if (structure.Instance != null)
+                {
+                    Destroy(structure.Instance);
+                }
+            }
+
+            placedStructures.Clear();
+            CancelPlacement();
+        }
+
+        public void BeginPlacement()
+        {
+            if (planet == null || grid == null)
+            {
+                Debug.LogWarning("Cannot begin placement without an active planet.");
+                return;
+            }
+
+            EnsurePreviewInstance();
+            isPlacing = true;
+            menu?.UpdateBuildButtonState(ActiveStructureName, true);
+        }
+
+        public void CancelPlacement()
+        {
+            if (!isPlacing && previewInstance == null)
+            {
+                return;
+            }
+
+            isPlacing = false;
+            if (previewInstance != null)
+            {
+                previewInstance.SetActive(false);
+            }
+
+            visualizer?.Hide();
+            menu?.UpdateBuildButtonState(ActiveStructureName, false);
+        }
+
+        private void Update()
+        {
+            if (!isPlacing || planet == null || grid == null)
+            {
+                return;
+            }
+
+            if (mainCamera == null)
+            {
+                mainCamera = Camera.main;
+                if (mainCamera == null)
+                {
+                    return;
+                }
+            }
+
+            if (!TrySamplePlacementCell(out var frame))
+            {
+                if (previewInstance != null)
+                {
+                    previewInstance.SetActive(false);
+                }
+
+                visualizer?.Hide();
+                return;
+            }
+
+            var placementValid = ValidatePlacement(frame);
+            UpdatePreview(frame, placementValid);
+            visualizer?.ShowArea(grid, frame.Cell, placementValid);
+
+            if (placementValid && Input.GetMouseButtonDown(0))
+            {
+                PlaceStructure(frame);
+            }
+            else if (Input.GetMouseButtonDown(1) || Input.GetKeyDown(KeyCode.Escape))
+            {
+                CancelPlacement();
+            }
+        }
+
+        private bool TrySamplePlacementCell(out CellFrame frame)
+        {
+            frame = default;
+            var ray = mainCamera.ScreenPointToRay(Input.mousePosition);
+            if (!TryRaycastPlanet(ray, out var direction))
+            {
+                return false;
+            }
+
+            var localDirection = planet.transform.InverseTransformDirection(direction);
+            var cell = grid.GetCellFromDirection(localDirection);
+            frame = grid.CalculateFrame(cell);
+            return true;
+        }
+
+        private bool TryRaycastPlanet(Ray ray, out Vector3 direction)
+        {
+            direction = Vector3.zero;
+            var center = planet.transform.position;
+            var adjustedRadius = planet.Radius + 1200f;
+            var oc = ray.origin - center;
+            var a = Vector3.Dot(ray.direction, ray.direction);
+            var b = 2f * Vector3.Dot(oc, ray.direction);
+            var c = Vector3.Dot(oc, oc) - adjustedRadius * adjustedRadius;
+            var discriminant = b * b - 4f * a * c;
+            if (discriminant < 0f)
+            {
+                return false;
+            }
+
+            var sqrt = Mathf.Sqrt(discriminant);
+            var t = (-b - sqrt) / (2f * a);
+            if (t < 0f)
+            {
+                t = (-b + sqrt) / (2f * a);
+                if (t < 0f)
+                {
+                    return false;
+                }
+            }
+
+            var hitPoint = ray.origin + ray.direction * t;
+            direction = (hitPoint - center).normalized;
+            return true;
+        }
+
+        private bool ValidatePlacement(CellFrame frame)
+        {
+            var localPosition = planet.transform.InverseTransformPoint(frame.Center);
+            var aboveSeaLevel = localPosition.magnitude >= planet.SeaLevel;
+            var unoccupied = !placedStructures.ContainsKey(frame.Cell);
+            return aboveSeaLevel && unoccupied;
+        }
+
+        private void UpdatePreview(CellFrame frame, bool placementValid)
+        {
+            EnsurePreviewInstance();
+            if (previewInstance == null)
+            {
+                return;
+            }
+
+            var dimensions = activeStructure.Dimensions;
+            var offset = frame.Normal * (dimensions.y * 0.5f);
+            var forward = frame.Forward.sqrMagnitude > 0.001f
+                ? frame.Forward
+                : Vector3.ProjectOnPlane(mainCamera.transform.forward, frame.Normal).normalized;
+            if (forward.sqrMagnitude < 0.001f)
+            {
+                forward = Vector3.Cross(frame.Normal, Vector3.right);
+                if (forward.sqrMagnitude < 0.001f)
+                {
+                    forward = Vector3.Cross(frame.Normal, Vector3.forward);
+                }
+            }
+
+            var rotation = Quaternion.LookRotation(forward.normalized, frame.Normal);
+            previewInstance.transform.SetPositionAndRotation(frame.Center + offset, rotation);
+            previewInstance.transform.localScale = dimensions;
+            var validColor = activeStructure != null ? activeStructure.PreviewColor : validPreviewColor;
+            previewRenderer.sharedMaterial.color = placementValid ? validColor : invalidPreviewColor;
+            previewInstance.SetActive(true);
+        }
+
+        private void PlaceStructure(CellFrame frame)
+        {
+            var instance = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            instance.name = activeStructure.DisplayName;
+            instance.transform.SetParent(structureRoot != null ? structureRoot : planet.transform, false);
+            var collider = instance.GetComponent<Collider>();
+            if (collider != null)
+            {
+                Destroy(collider);
+            }
+
+            var dimensions = activeStructure.Dimensions;
+            var offset = frame.Normal * (dimensions.y * 0.5f);
+            var forward = frame.Forward.sqrMagnitude > 0.001f
+                ? frame.Forward
+                : Vector3.Cross(frame.Normal, Vector3.right);
+            if (forward.sqrMagnitude < 0.001f)
+            {
+                forward = Vector3.Cross(frame.Normal, Vector3.forward);
+            }
+
+            var rotation = Quaternion.LookRotation(forward.normalized, frame.Normal);
+            instance.transform.SetPositionAndRotation(frame.Center + offset, rotation);
+            instance.transform.localScale = dimensions;
+
+            var renderer = instance.GetComponent<MeshRenderer>();
+            renderer.sharedMaterial = GetMaterial(activeStructure.StructureColor);
+
+            placedStructures[frame.Cell] = new PlacedStructure(frame.Cell, activeStructure, instance);
+            menu?.AppendEventLog($"Placed {activeStructure.DisplayName} at {frame.Cell}.");
+        }
+
+        private void EnsurePreviewInstance()
+        {
+            if (previewInstance != null)
+            {
+                return;
+            }
+
+            if (planet == null)
+            {
+                return;
+            }
+
+            var shader = Shader.Find("Unlit/Color");
+            previewMaterial = new Material(shader)
+            {
+                color = validPreviewColor,
+                name = "BuildingPreviewMaterial"
+            };
+
+            previewInstance = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            previewInstance.name = "BuildingPreview";
+            previewInstance.transform.SetParent(planet.transform, false);
+            var collider = previewInstance.GetComponent<Collider>();
+            if (collider != null)
+            {
+                Destroy(collider);
+            }
+
+            previewRenderer = previewInstance.GetComponent<MeshRenderer>();
+            previewRenderer.sharedMaterial = previewMaterial;
+            previewInstance.SetActive(false);
+        }
+
+        private void ClearPreviewInstance()
+        {
+            if (previewInstance != null)
+            {
+                Destroy(previewInstance);
+                previewInstance = null;
+                previewRenderer = null;
+            }
+
+            if (previewMaterial != null)
+            {
+                Destroy(previewMaterial);
+                previewMaterial = null;
+            }
+        }
+
+        private void RebuildVisualizer()
+        {
+            visualizer?.Dispose();
+            visualizer = null;
+
+            if (planet == null)
+            {
+                return;
+            }
+
+            EnsureGridMaterials();
+            visualizer = new PlanetGridVisualizer(planet.transform, gridAllowedMaterial, gridBlockedMaterial, gridElevationOffset);
+        }
+
+        private void RebuildStructureRoot()
+        {
+            if (structureRoot != null)
+            {
+                Destroy(structureRoot.gameObject);
+            }
+
+            if (planet == null)
+            {
+                structureRoot = null;
+                return;
+            }
+
+            var rootGO = new GameObject("PlacedStructures");
+            structureRoot = rootGO.transform;
+            structureRoot.SetParent(planet.transform, false);
+        }
+
+        private void EnsureGridMaterials()
+        {
+            var shader = Shader.Find("Unlit/Color");
+            if (gridAllowedMaterial == null)
+            {
+                gridAllowedMaterial = new Material(shader)
+                {
+                    color = allowedGridColor,
+                    name = "GridAllowedMaterial"
+                };
+            }
+
+            if (gridBlockedMaterial == null)
+            {
+                gridBlockedMaterial = new Material(shader)
+                {
+                    color = blockedGridColor,
+                    name = "GridBlockedMaterial"
+                };
+            }
+        }
+
+        private static Material GetMaterial(Color color)
+        {
+            if (!MaterialCache.TryGetValue(color, out var material) || material == null)
+            {
+                material = new Material(Shader.Find("Standard")) { color = color };
+                MaterialCache[color] = material;
+            }
+
+            return material;
+        }
+
+        private struct PlacedStructure
+        {
+            public readonly PlanetGridCell Cell;
+            public readonly BuildableStructure Definition;
+            public readonly GameObject Instance;
+
+            public PlacedStructure(PlanetGridCell cell, BuildableStructure definition, GameObject instance)
+            {
+                Cell = cell;
+                Definition = definition;
+                Instance = instance;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Game/Construction/BuildingPlacementController.cs.meta
+++ b/Assets/Scripts/Game/Construction/BuildingPlacementController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7cf8dd7d0c2a45e3af69c59d4b0f3886
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/Construction/PlanetGrid.cs
+++ b/Assets/Scripts/Game/Construction/PlanetGrid.cs
@@ -1,0 +1,260 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using WH30K.Planet;
+
+namespace WH30K.Gameplay.Construction
+{
+    /// <summary>
+    /// Represents a cube-sphere aligned grid that wraps the entire planet surface.
+    /// Provides conversion helpers between world positions and discrete grid cells.
+    /// </summary>
+    public sealed class PlanetGrid
+    {
+        private readonly LODPlanet planet;
+        private readonly Transform planetTransform;
+        private readonly int cellsPerFace;
+        private readonly float inverseResolution;
+
+        public int CellsPerFace => cellsPerFace;
+
+        public PlanetGrid(LODPlanet planet, int cellsPerFace)
+        {
+            this.planet = planet;
+            planetTransform = planet.transform;
+            this.cellsPerFace = Mathf.Max(4, cellsPerFace);
+            inverseResolution = 1f / this.cellsPerFace;
+        }
+
+        public PlanetGridCell GetCellFromWorld(Vector3 worldPosition)
+        {
+            var local = planetTransform.InverseTransformPoint(worldPosition);
+            return GetCellFromDirection(local.normalized);
+        }
+
+        public PlanetGridCell GetCellFromDirection(Vector3 direction)
+        {
+            direction.Normalize();
+
+            var absX = Mathf.Abs(direction.x);
+            var absY = Mathf.Abs(direction.y);
+            var absZ = Mathf.Abs(direction.z);
+
+            int face;
+            float u;
+            float v;
+
+            if (absX >= absY && absX >= absZ)
+            {
+                if (direction.x >= 0f)
+                {
+                    face = (int)CubeFace.PositiveX;
+                    u = -direction.z / absX;
+                    v = direction.y / absX;
+                }
+                else
+                {
+                    face = (int)CubeFace.NegativeX;
+                    u = direction.z / absX;
+                    v = direction.y / absX;
+                }
+            }
+            else if (absY >= absX && absY >= absZ)
+            {
+                if (direction.y >= 0f)
+                {
+                    face = (int)CubeFace.PositiveY;
+                    u = direction.x / absY;
+                    v = -direction.z / absY;
+                }
+                else
+                {
+                    face = (int)CubeFace.NegativeY;
+                    u = direction.x / absY;
+                    v = direction.z / absY;
+                }
+            }
+            else
+            {
+                if (direction.z >= 0f)
+                {
+                    face = (int)CubeFace.PositiveZ;
+                    u = direction.x / absZ;
+                    v = direction.y / absZ;
+                }
+                else
+                {
+                    face = (int)CubeFace.NegativeZ;
+                    u = -direction.x / absZ;
+                    v = direction.y / absZ;
+                }
+            }
+
+            var uNorm = (u + 1f) * 0.5f;
+            var vNorm = (v + 1f) * 0.5f;
+
+            var x = Mathf.Clamp(Mathf.FloorToInt(uNorm * cellsPerFace), 0, cellsPerFace - 1);
+            var y = Mathf.Clamp(Mathf.FloorToInt(vNorm * cellsPerFace), 0, cellsPerFace - 1);
+            return new PlanetGridCell(face, x, y);
+        }
+
+        public Vector3 GetCellCenterWorld(PlanetGridCell cell)
+        {
+            var local = GetCellCenterLocal(cell);
+            return planetTransform.TransformPoint(local);
+        }
+
+        public Vector3 GetCellCenterLocal(PlanetGridCell cell)
+        {
+            var direction = GetDirection(cell);
+            return planet.EvaluateSurfacePoint(direction);
+        }
+
+        public Vector3 GetDirection(PlanetGridCell cell)
+        {
+            var uv = GetCellUV(cell);
+            return CubeToDirection(cell.Face, uv);
+        }
+
+        public Vector2 GetCellUV(PlanetGridCell cell)
+        {
+            return new Vector2((cell.X + 0.5f) * inverseResolution, (cell.Y + 0.5f) * inverseResolution);
+        }
+
+        public PlanetGridCell OffsetCell(PlanetGridCell cell, int offsetX, int offsetY)
+        {
+            var uv = GetCellUV(cell);
+            uv += new Vector2(offsetX * inverseResolution, offsetY * inverseResolution);
+            var direction = CubeToDirection(cell.Face, uv);
+            return GetCellFromDirection(direction);
+        }
+
+        public CellFrame CalculateFrame(PlanetGridCell cell)
+        {
+            var uv = GetCellUV(cell);
+            var centerLocal = planet.EvaluateSurfacePoint(CubeToDirection(cell.Face, uv));
+            var centerWorld = planetTransform.TransformPoint(centerLocal);
+            var planetCenter = planetTransform.position;
+            var normalWorld = (centerWorld - planetCenter).sqrMagnitude > 0.001f
+                ? (centerWorld - planetCenter).normalized
+                : planetTransform.up;
+
+            var delta = inverseResolution;
+            var rightLocal = planet.EvaluateSurfacePoint(CubeToDirection(cell.Face, uv + new Vector2(delta, 0f)));
+            var leftLocal = planet.EvaluateSurfacePoint(CubeToDirection(cell.Face, uv - new Vector2(delta, 0f)));
+            var forwardLocal = planet.EvaluateSurfacePoint(CubeToDirection(cell.Face, uv + new Vector2(0f, delta)));
+            var backLocal = planet.EvaluateSurfacePoint(CubeToDirection(cell.Face, uv - new Vector2(0f, delta)));
+
+            var rightWorld = planetTransform.TransformPoint(rightLocal);
+            var leftWorld = planetTransform.TransformPoint(leftLocal);
+            var forwardWorld = planetTransform.TransformPoint(forwardLocal);
+            var backWorld = planetTransform.TransformPoint(backLocal);
+
+            var rightVector = (rightWorld - leftWorld) * 0.5f;
+            var forwardVector = (forwardWorld - backWorld) * 0.5f;
+
+            var rightDir = rightVector.sqrMagnitude > 0.001f ? rightVector.normalized : Vector3.right;
+            var forwardDir = forwardVector.sqrMagnitude > 0.001f ? forwardVector.normalized : Vector3.forward;
+
+            return new CellFrame(cell, centerWorld, normalWorld, rightDir, forwardDir,
+                rightVector.magnitude, forwardVector.magnitude);
+        }
+
+        private static Vector3 CubeToDirection(int face, Vector2 uv)
+        {
+            var u = Mathf.Clamp((uv.x * 2f) - 1f, -2f, 2f);
+            var v = Mathf.Clamp((uv.y * 2f) - 1f, -2f, 2f);
+
+            switch ((CubeFace)face)
+            {
+                case CubeFace.PositiveX:
+                    return new Vector3(1f, v, -u).normalized;
+                case CubeFace.NegativeX:
+                    return new Vector3(-1f, v, u).normalized;
+                case CubeFace.PositiveY:
+                    return new Vector3(u, 1f, -v).normalized;
+                case CubeFace.NegativeY:
+                    return new Vector3(u, -1f, v).normalized;
+                case CubeFace.PositiveZ:
+                    return new Vector3(u, v, 1f).normalized;
+                case CubeFace.NegativeZ:
+                    return new Vector3(-u, v, -1f).normalized;
+                default:
+                    return Vector3.up;
+            }
+        }
+
+        private enum CubeFace
+        {
+            PositiveX = 0,
+            NegativeX = 1,
+            PositiveY = 2,
+            NegativeY = 3,
+            PositiveZ = 4,
+            NegativeZ = 5
+        }
+    }
+
+    public readonly struct PlanetGridCell : IEquatable<PlanetGridCell>
+    {
+        public int Face { get; }
+        public int X { get; }
+        public int Y { get; }
+
+        public PlanetGridCell(int face, int x, int y)
+        {
+            Face = Mathf.Clamp(face, 0, 5);
+            X = x;
+            Y = y;
+        }
+
+        public bool Equals(PlanetGridCell other)
+        {
+            return Face == other.Face && X == other.X && Y == other.Y;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is PlanetGridCell other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hash = Face;
+                hash = (hash * 397) ^ X;
+                hash = (hash * 397) ^ Y;
+                return hash;
+            }
+        }
+
+        public override string ToString()
+        {
+            return $"Face {Face} ({X}, {Y})";
+        }
+    }
+
+    public readonly struct CellFrame
+    {
+        public PlanetGridCell Cell { get; }
+        public Vector3 Center { get; }
+        public Vector3 Normal { get; }
+        public Vector3 Right { get; }
+        public Vector3 Forward { get; }
+        public float RightExtent { get; }
+        public float ForwardExtent { get; }
+
+        public CellFrame(PlanetGridCell cell, Vector3 center, Vector3 normal, Vector3 right, Vector3 forward,
+            float rightExtent, float forwardExtent)
+        {
+            Cell = cell;
+            Center = center;
+            Normal = normal;
+            Right = right;
+            Forward = forward;
+            RightExtent = rightExtent;
+            ForwardExtent = forwardExtent;
+        }
+    }
+}

--- a/Assets/Scripts/Game/Construction/PlanetGrid.cs.meta
+++ b/Assets/Scripts/Game/Construction/PlanetGrid.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3abdb146a02f47f599167090c11b7c3b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/Construction/PlanetGridVisualizer.cs
+++ b/Assets/Scripts/Game/Construction/PlanetGridVisualizer.cs
@@ -1,0 +1,146 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace WH30K.Gameplay.Construction
+{
+    /// <summary>
+    /// Helper that manages the visual overlay for the placement grid.
+    /// It builds a small cluster of quads around the active placement cell.
+    /// </summary>
+    public sealed class PlanetGridVisualizer
+    {
+        private readonly Transform root;
+        private readonly Material allowedMaterial;
+        private readonly Material blockedMaterial;
+        private readonly float elevationOffset;
+        private readonly List<GridTile> tiles = new List<GridTile>();
+
+        private struct GridTile
+        {
+            public readonly GameObject GameObject;
+            public readonly MeshRenderer Renderer;
+
+            public GridTile(GameObject go, MeshRenderer renderer)
+            {
+                GameObject = go;
+                Renderer = renderer;
+            }
+        }
+
+        public PlanetGridVisualizer(Transform parent, Material allowedMaterial, Material blockedMaterial, float elevationOffset)
+        {
+            this.allowedMaterial = allowedMaterial;
+            this.blockedMaterial = blockedMaterial;
+            this.elevationOffset = elevationOffset;
+
+            var rootGO = new GameObject("PlacementGridOverlay");
+            root = rootGO.transform;
+            root.SetParent(parent, false);
+            root.gameObject.SetActive(false);
+        }
+
+        public void Hide()
+        {
+            if (root != null)
+            {
+                root.gameObject.SetActive(false);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (root != null)
+            {
+                Object.Destroy(root.gameObject);
+            }
+
+            tiles.Clear();
+        }
+
+        public void ShowArea(PlanetGrid grid, PlanetGridCell centerCell, bool placementValid)
+        {
+            if (root == null)
+            {
+                return;
+            }
+
+            var frames = GatherFrames(grid, centerCell);
+            EnsureTileCount(frames.Count);
+
+            for (var i = 0; i < frames.Count; i++)
+            {
+                var frame = frames[i];
+                var tile = tiles[i];
+                UpdateTile(tile, frame, placementValid);
+            }
+
+            for (var i = frames.Count; i < tiles.Count; i++)
+            {
+                tiles[i].GameObject.SetActive(false);
+            }
+
+            root.gameObject.SetActive(true);
+        }
+
+        private void UpdateTile(GridTile tile, CellFrame frame, bool placementValid)
+        {
+            var go = tile.GameObject;
+            go.SetActive(true);
+
+            var position = frame.Center + frame.Normal * elevationOffset;
+            var forward = frame.Forward.sqrMagnitude > 0.001f
+                ? frame.Forward
+                : Vector3.forward;
+            var rotation = Quaternion.LookRotation(forward, frame.Normal);
+            go.transform.SetPositionAndRotation(position, rotation);
+            go.transform.localScale = new Vector3(Mathf.Max(1f, frame.RightExtent), Mathf.Max(1f, frame.ForwardExtent), 1f);
+
+            var renderer = tile.Renderer;
+            renderer.sharedMaterial = placementValid ? allowedMaterial : blockedMaterial;
+        }
+
+        private List<CellFrame> GatherFrames(PlanetGrid grid, PlanetGridCell centerCell)
+        {
+            var frames = new List<CellFrame>();
+            var visited = new HashSet<PlanetGridCell>();
+            for (var y = -1; y <= 1; y++)
+            {
+                for (var x = -1; x <= 1; x++)
+                {
+                    var target = grid.OffsetCell(centerCell, x, y);
+                    if (!visited.Add(target))
+                    {
+                        continue;
+                    }
+
+                    frames.Add(grid.CalculateFrame(target));
+                }
+            }
+
+            return frames;
+        }
+
+        private void EnsureTileCount(int count)
+        {
+            var shader = Shader.Find("Unlit/Color");
+            while (tiles.Count < count)
+            {
+                var quad = GameObject.CreatePrimitive(PrimitiveType.Quad);
+                quad.name = $"GridTile_{tiles.Count:00}";
+                quad.transform.SetParent(root, false);
+                var collider = quad.GetComponent<Collider>();
+                if (collider != null)
+                {
+                    Object.Destroy(collider);
+                }
+
+                var renderer = quad.GetComponent<MeshRenderer>();
+                renderer.sharedMaterial = allowedMaterial != null
+                    ? allowedMaterial
+                    : new Material(shader) { color = new Color(0.5f, 1f, 0.5f, 0.3f) };
+
+                tiles.Add(new GridTile(quad, renderer));
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Game/Construction/PlanetGridVisualizer.cs.meta
+++ b/Assets/Scripts/Game/Construction/PlanetGridVisualizer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5d47c2c4ba87484a82f77c1f3f5aa4a3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Planet/PlanetBootstrap.cs
+++ b/Assets/Scripts/Planet/PlanetBootstrap.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using WH30K.CameraSystem;
 using WH30K.Game;
 using WH30K.Planet;
+using WH30K.Gameplay.Construction;
 using WH30K.Sim.Environment;
 using WH30K.Sim.Events;
 using WH30K.Sim.Resources;
@@ -20,6 +21,7 @@ namespace WH30K.Gameplay
     [RequireComponent(typeof(EnvironmentState))]
     [RequireComponent(typeof(ColonyEventSystem))]
     [RequireComponent(typeof(Settlement))]
+    [RequireComponent(typeof(BuildingPlacementController))]
     public class PlanetBootstrap : MonoBehaviour
     {
         [Header("Planet")]
@@ -50,6 +52,7 @@ namespace WH30K.Gameplay
         private ColonyEventSystem colonyEventSystem;
         private Settlement settlement;
         private SimpleOrbitCamera orbitCamera;
+        private BuildingPlacementController buildingPlacement;
 
 #if UNITY_EDITOR
         private Transform debugMarkerRoot;
@@ -87,6 +90,7 @@ namespace WH30K.Gameplay
             orbitCamera = UnityEngine.Camera.main != null
                 ? UnityEngine.Camera.main.GetComponent<SimpleOrbitCamera>()
                 : null;
+            buildingPlacement = GetComponent<BuildingPlacementController>();
 
             LoadTerrainMaterial();
         }
@@ -126,6 +130,8 @@ namespace WH30K.Gameplay
             {
                 orbitCamera.SetTarget(planetRoot, planet.Radius);
             }
+
+            buildingPlacement?.AttachToPlanet(planet);
 
             resourceSystem.ResetForNewGame(definition);
             environmentState.ResetForNewGame(definition);
@@ -214,6 +220,8 @@ namespace WH30K.Gameplay
             {
                 orbitCamera.SetTarget(planetRoot, planet.Radius);
             }
+
+            buildingPlacement?.AttachToPlanet(planet);
 
             resourceSystem.LoadFromSnapshot(save.resources, definition);
             environmentState.LoadFromSnapshot(save.environment, definition);


### PR DESCRIPTION
## Summary
- add a reusable buildable structure definition and default Frontier Outpost asset discoverable from Resources
- implement a planet-spanning cube-sphere grid, placement controller and grid visualiser to drive structure previews and validation
- extend the HUD with a build button and ensure PlanetBootstrap wires the placement system to newly generated or loaded planets

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68d3c19eced0832290d5ff15d0904568