### PR TITLE
Add building placement controller to main scene

### DIFF
--- a/Assets/Scenes/Prototype/WH30K_VS01.unity
+++ b/Assets/Scenes/Prototype/WH30K_VS01.unity
@@ -138,6 +138,7 @@ GameObject:
   - component: {fileID: 100005}
   - component: {fileID: 100006}
   - component: {fileID: 100007}
+  - component: {fileID: 100008}
   m_Layer: 0
   m_Name: GameRoot
   m_TagString: Untagged
@@ -243,6 +244,24 @@ MonoBehaviour:
   populationGrowthRate: 0.05
   workforceRatio: 0.62
   buildingSpacing: 220
+--- !u!114 &100008
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7cf8dd7d0c2a45e3af69c59d4b0f3886, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  cellsPerFace: 96
+  gridElevationOffset: 6
+  validPreviewColor: {r: 0.5, g: 1, b: 0.5, a: 0.6}
+  invalidPreviewColor: {r: 1, g: 0.35, b: 0.35, a: 0.6}
+  allowedGridColor: {r: 0.6, g: 1, b: 0.6, a: 0.35}
+  blockedGridColor: {r: 1, g: 0.4, b: 0.4, a: 0.35}
 --- !u!1 &110000
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Summary
- attach the BuildingPlacementController to the GameRoot object in WH30K_VS01
- populate the controller with its default grid and preview colour settings so the placement UI can interact with it

## Testing
- not run (Unity Editor required)


------
https://chatgpt.com/codex/tasks/task_e_68d3c82e7cf88322a5ea6b7c3eda5173