### PR TITLE
Ensure colony events continue after resolving choices

### DIFF
--- a/Assets/Scripts/Sim/Events/ColonyEventSystem.cs
+++ b/Assets/Scripts/Sim/Events/ColonyEventSystem.cs
@@ -89,6 +89,7 @@ namespace WH30K.Sim.Events
                 temperatureDelta = -0.04f
             });
             menu?.AppendEventLog("Mandated safety upgrades across the industrial sector.");
+            ScheduleNextEvent();
         }
 
         private void OnOverdriveChosen()
@@ -103,6 +104,22 @@ namespace WH30K.Sim.Events
                 temperatureDelta = 0.09f
             });
             menu?.AppendEventLog("Ordered furnaces into overdrive to meet production quotas.");
+            ScheduleNextEvent();
+        }
+
+        private void ScheduleNextEvent()
+        {
+            if (rng == null || !isActiveAndEnabled)
+            {
+                return;
+            }
+
+            if (eventCoroutine != null)
+            {
+                StopCoroutine(eventCoroutine);
+            }
+
+            eventCoroutine = StartCoroutine(EventRoutine());
         }
 
 #if UNITY_EDITOR


### PR DESCRIPTION
## Summary
- restart the colony event coroutine after each narrative choice so new events continue to appear
- guard the scheduler against duplicate coroutines and inactive sessions

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68d3ea4d6a508322b6e1acaa50793b4f